### PR TITLE
Github actions for update sigma rules

### DIFF
--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -29,15 +29,17 @@ jobs:
       - name: setup Python for use script
         run: |
           curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/requirements.txt > requirements.txt
-          cat requirements.txt
           pip install -r requirements.txt
+          rm requirements.txt
 
       - name: Update sigma rules
         run: |
-          cd sigma-repo
+          pushd sigma-repo
           sh convert.sh
           rm -rf ../sigma
           mv hayabusa_rules/rules/windows ../sigma
+          popd
+          rm -rf sigma-repo
 
       - name: Create Text
         id: create-text
@@ -65,8 +67,6 @@ jobs:
           branch: update-sigmarule
           delete-branch: true
           title: '[Auto] Sigma Update report'
-          add-paths:
-            sigma/*
           body: |
             ${{ env.action_date }} Update report
 

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -1,7 +1,7 @@
 name: Pipline for update Sigma rule
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 8,14,20 * * *'
 
 jobs:
   updateSigmaRule:

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -43,7 +43,6 @@ jobs:
         id: create-text
         continue-on-error: true
         run: |
-          echo test >> test.txt
           echo "action_date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
           echo "change_exist=true" >> $GITHUB_ENV
           git_new=$(git status -s | grep "??" | sed "s/?? /- /g" | sed -z 's/\n/\\n/g')
@@ -55,6 +54,7 @@ jobs:
           if [[ "$(git status)" =~ "nothing to commit," ]]; then
             echo "change_exist=false" >> $GITHUB_ENV
           fi
+          git status
 
       - name: Create Pull Request
         if: steps.create-text.outputs.change_exist == 'true'

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -1,0 +1,39 @@
+name: Pipline for update Sigma rule
+# on: push
+
+jobs:
+  updateSigmaRule:
+    name: updateSigmaRule
+    runs-on: ubuntu-20.04
+    steps:
+      - name: clone hayabusa-repo
+        uses: actions/checkout@v2
+
+      - name: clone sigmac
+        uses: actions/checkout@v2
+        with:
+          repository: SigmaHQ/sigma
+          path: sigma-repo
+
+      - name: get Hayabusa backend for sigmac
+        run: |
+          curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/convert.sh > sigma-repo/tools/sigma/convert.sh
+          curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/splitter.py > sigma-repo/splitter.py
+          curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/hayabusa.py > sigma-repo/hayabusa.py
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: setup Python for use script
+        run: |
+          curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/requirements.txt > requirements.txt
+          cat requirements.txt
+          pip install -r requirements.txt
+
+      - name: test echo
+        run: |
+          cd sigma-repo
+          ls
+          python -V

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -96,6 +96,6 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -54,10 +54,9 @@ jobs:
           if [[ "$(git status)" =~ "nothing to commit," ]]; then
             echo "change_exist=false" >> $GITHUB_ENV
           fi
-          git status
 
       - name: Create Pull Request
-        if: steps.create-text.outputs.change_exist == 'true'
+        if: env.change_exist == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
@@ -69,7 +68,7 @@ jobs:
           add-path:
             sigma/*
           body: |
-            Update report
+            ${{ env.action_date }} Update report
 
             <details><summary>New files</summary>
             ${{ steps.create-text.outputs.git_new }}

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: clone hayabusa-repo
         uses: actions/checkout@v2
+        with:
+          ref: develop
 
       - name: clone sigmac
         uses: actions/checkout@v2
@@ -66,7 +68,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Sigma Rule Update (${{ env.action_date }})
-          branch: update-sigmarule
+          branch: rules/auto-sigma-update
           delete-branch: true
           title: '[Auto] Sigma Update report'
           body: |

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -1,5 +1,7 @@
 name: Pipline for update Sigma rule
-on: push
+on:
+  schedule:
+    - cron: '00 08 * * *'
 
 jobs:
   updateSigmaRule:

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -1,7 +1,7 @@
 name: Pipline for update Sigma rule
 on:
   schedule:
-    - cron: '0 8,14,20 * * *'
+    - cron: '0 20 * * *'
 
 jobs:
   updateSigmaRule:

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -65,7 +65,7 @@ jobs:
           branch: update-sigmarule
           delete-branch: true
           title: '[Auto] Sigma Update report'
-          add-path:
+          add-paths:
             sigma/*
           body: |
             ${{ env.action_date }} Update report

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -45,12 +45,12 @@ jobs:
         run: |
           echo "action_date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
           echo "change_exist=true" >> $GITHUB_ENV
-          git_new=$(git status -s | grep "??" | sed "s/?? /- /g" | sed -z 's/\n/\\n/g')
-          git_mod=$(git status | grep "modified:" | sed -e "s/\s*modified:\s*/- /g" | sed -z 's/\n/\\n/g')
-          git_del=$(git status | grep "deleted:"  | sed -e "s/\s*deleted:\s*/- /g" | sed -z 's/\n/\\n/g')
-          echo "::set-output name=git_new::$git_new"
-          echo "::set-output name=git_mod::$git_mod"
-          echo "::set-output name=git_del::$git_del"
+          git_new=$(git status -s | grep "??" | sed "s/?? /- /g")
+          git_mod=$(git status | grep "modified:" | sed -e "s/\s*modified:\s*/- /g")
+          git_del=$(git status | grep "deleted:"  | sed -e "s/\s*deleted:\s*/- /g")
+          echo "::set-output name=git_new::${git_new//$'\n'/'%0A'}"
+          echo "::set-output name=git_mod::${git_mod//$'\n'/'%0A'}"
+          echo "::set-output name=git_del::${git_del//$'\n'/'%0A'}"
           if [[ "$(git status)" =~ "nothing to commit," ]]; then
             echo "change_exist=false" >> $GITHUB_ENV
           fi
@@ -71,15 +71,21 @@ jobs:
             ${{ env.action_date }} Update report
 
             <details><summary>New files</summary>
+
             ${{ steps.create-text.outputs.git_new }}
+
             </details>
 
             <details><summary>Modified files</summary>
+
             ${{ steps.create-text.outputs.git_mod }}
+
             </details>
 
             <details><summary>Deleted files</summary>
+
             ${{ steps.create-text.outputs.git_del }}
+
             </details>
           assignees: itiB
           reviewers: itiB

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -1,7 +1,7 @@
 name: Pipline for update Sigma rule
 on:
   schedule:
-    - cron: '00 08 * * *'
+    - cron: '0 8 * * *'
 
 jobs:
   updateSigmaRule:
@@ -91,3 +91,11 @@ jobs:
             </details>
           assignees: itiB
           reviewers: itiB
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.PAT }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/update-sigmarule.yml
+++ b/.github/workflows/update-sigmarule.yml
@@ -1,5 +1,5 @@
 name: Pipline for update Sigma rule
-# on: push
+on: push
 
 jobs:
   updateSigmaRule:
@@ -17,9 +17,9 @@ jobs:
 
       - name: get Hayabusa backend for sigmac
         run: |
-          curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/convert.sh > sigma-repo/tools/sigma/convert.sh
+          curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/convert.sh > sigma-repo/convert.sh
           curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/splitter.py > sigma-repo/splitter.py
-          curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/hayabusa.py > sigma-repo/hayabusa.py
+          curl https://raw.githubusercontent.com/Yamato-Security/hayabusa/main/tools/sigmac/hayabusa.py > sigma-repo/tools/sigma/backends/hayabusa.py
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -32,8 +32,55 @@ jobs:
           cat requirements.txt
           pip install -r requirements.txt
 
-      - name: test echo
+      - name: Update sigma rules
         run: |
           cd sigma-repo
-          ls
-          python -V
+          sh convert.sh
+          rm -rf ../sigma
+          mv hayabusa_rules/rules/windows ../sigma
+
+      - name: Create Text
+        id: create-text
+        continue-on-error: true
+        run: |
+          echo test >> test.txt
+          echo "action_date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+          echo "change_exist=true" >> $GITHUB_ENV
+          git_new=$(git status -s | grep "??" | sed "s/?? /- /g" | sed -z 's/\n/\\n/g')
+          git_mod=$(git status | grep "modified:" | sed -e "s/\s*modified:\s*/- /g" | sed -z 's/\n/\\n/g')
+          git_del=$(git status | grep "deleted:"  | sed -e "s/\s*deleted:\s*/- /g" | sed -z 's/\n/\\n/g')
+          echo "::set-output name=git_new::$git_new"
+          echo "::set-output name=git_mod::$git_mod"
+          echo "::set-output name=git_del::$git_del"
+          if [[ "$(git status)" =~ "nothing to commit," ]]; then
+            echo "change_exist=false" >> $GITHUB_ENV
+          fi
+
+      - name: Create Pull Request
+        if: steps.create-text.outputs.change_exist == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Sigma Rule Update (${{ env.action_date }})
+          branch: update-sigmarule
+          delete-branch: true
+          title: '[Auto] Sigma Update report'
+          add-path:
+            sigma/*
+          body: |
+            Update report
+
+            <details><summary>New files</summary>
+            ${{ steps.create-text.outputs.git_new }}
+            </details>
+
+            <details><summary>Modified files</summary>
+            ${{ steps.create-text.outputs.git_mod }}
+            </details>
+
+            <details><summary>Deleted files</summary>
+            ${{ steps.create-text.outputs.git_del }}
+            </details>
+          assignees: itiB
+          reviewers: itiB


### PR DESCRIPTION
## 内容

SigmaルールをAutoUpdateする機能

### SigmaRuleアップデートの流れ

Sigmaに更新があれば勝手に `rules/auto-sigma-update` にプルリクが日々作られ、マージされていく。
わざわざプルリクを作るのはその日になんのルールが追加、削除されたかわかりやすくなるから。

sample: https://github.com/Yamato-Security/hayabusa-rules/pull/5

アップデートされた`sigma-latest`ディレクトリをもとにルールの正当性を検証、よければdevelopから切ったブランチ(rules/add-sigma-xxx)にルールを追加してプルリクを作成、developにマージしていく。

```mermaid
graph LR;
sigma-latest --Create HayabusaRules-->rules/auto-sigma-update;
rules/auto-sigma-update -- Auto Merge --> sigma-latest;
sigma-latest -.- c{Rule check & create PR};
c{Rule check & create PR} -..-> rules/add-sigma-xxx;
rules/add-sigma-xxx --> develop;
develop -->main;
```

## レビューのポイント

- 更新があると作られる https://github.com/Yamato-Security/hayabusa-rules/pull/5 は見やすいか
- ブランチ戦略はこれでいいか

closes #3 