### PR TITLE
Rules to detect bad Windows drivers

### DIFF
--- a/config/eventkey_alias.txt
+++ b/config/eventkey_alias.txt
@@ -148,6 +148,7 @@ ShareLocalPath,Event.EventData.ShareLocalPath
 ShareName,Event.EventData.ShareName
 SidHistory,Event.EventData.SidHistory
 Signature,Event.EventData.Signature
+SignatureStatus,Event.EventData.SignatureStatus
 Signed,Event.EventData.Signed
 Source,Event.System.Provider_Name
 SourceAddress,Event.EventData.SourceAddress

--- a/config/exclude_rules.txt
+++ b/config/exclude_rules.txt
@@ -9,6 +9,7 @@ f8931561-97f5-4c46-907f-0a4a592e47a7 # "Code Integrity Blocked Driver Load": pro
 c265cf08-3f99-46c1-8d59-328247057d57 # "User Added to Local Administrators"
 66b6be3d-55d0-4f47-9855-d69df21740ea # "Local User Creation"
 7b449a5e-1db5-4dd0-a2dc-4e3a67282538 # "Hidden Local User Creation".
+42c575ea-e41e-41f1-b248-8093c3e82a28 # "PsExec Tool Execution" win_tool_psexec.yml Note: rule not working to begin with.
 
 # Disabled due to too many false positives:
 71158e3f-df67-472b-930e-7d287acaa3e1 # "Execution Of Not Existing File"

--- a/hayabusa/non-default/alerts/Security/5038-6281-6410_CodeIntegrityProblem-PossibleModification.yml
+++ b/hayabusa/non-default/alerts/Security/5038-6281-6410_CodeIntegrityProblem-PossibleModification.yml
@@ -1,0 +1,34 @@
+author: Zach Mathis
+date: 2022/03/05
+modified:  2022/03/05
+
+title: Code Integrity Problem - Possible Modification
+title_jp: コードの整合性による問題 - 改ざんされた可能性がある
+details: 'File: %param1%'
+details_jp: 'ファイル: %param1%'
+description: Detects when hashes are not correct or a file does not meet Windows' security requirements.
+description_jp: 
+
+id: 
+level: low
+status: test
+detection:
+    selection:
+        Channel: Security
+        EventID: 
+            - 5038 
+            - 6281
+            - 6410
+    condition: selection
+falsepositives:
+    - most likely not malicious
+    - disk device error
+tags:
+    - attack.defense_evasion
+references:
+    - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-5038
+    - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-6281
+    - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-6410
+sample-evtx: 
+logsource: non-default
+ruletype: Hayabusa

--- a/hayabusa/sysmon/alerts/6_CodeSigning_DriverLoadedWithInvalidSignature.yml
+++ b/hayabusa/sysmon/alerts/6_CodeSigning_DriverLoadedWithInvalidSignature.yml
@@ -1,0 +1,31 @@
+author: Zach Mathis
+date: 2022/03/05
+modified:  2022/03/05
+
+title: Invalid Driver Signature
+title_jp: ドライバが不正な証明証で署名された
+details: 'Path: %ImageLoaded%  :  Signature: %Signature%'
+details_jp: 'パス: %ImageLoaded%  :  証明証: %Signature%'
+description: Loaded driver was signed with an invalid signature.
+description_jp: ロードされたドライバは不正な証明書で署名された。
+
+id: 1f666722-3948-40a2-9d78-d9d374477a90
+level: high
+status: test
+detection:
+    selection:
+        Channel: Microsoft-Windows-Sysmon/Operational
+        EventID:  6
+        Signed: true
+    filter:
+        SignatureStatus: Valid
+    condition: selection and not filter
+falsepositives:
+tags:
+    - attack.defense_evasion
+    - attack.t1553.002
+references:
+    - https://attack.mitre.org/techniques/T1553/002/
+sample-evtx: 
+logsource: sysmon
+ruletype: Hayabusa

--- a/hayabusa/sysmon/alerts/6_CodeSigning_UnsignedDriverLoaded.yml
+++ b/hayabusa/sysmon/alerts/6_CodeSigning_UnsignedDriverLoaded.yml
@@ -1,0 +1,30 @@
+author: Zach Mathis
+date: 2022/03/05
+modified:  2022/03/05
+
+title: Unsigned Driver Loaded
+title_jp: ロードされたドライバが署名されていない
+details: 'Path: %ImageLoaded%'
+details_jp: 'パス: %ImageLoaded%'
+description: 
+description_jp: 
+
+id: c837dd6d-0c91-4593-aeab-f6a1f3ca1961
+level: high
+status: test
+detection:
+    selection:
+        Channel: Microsoft-Windows-Sysmon/Operational
+        EventID:  6
+    filter:
+        Signed: true
+    condition: selection and not filter
+falsepositives:
+tags:
+    - attack.defense_evasion
+    - attack.t1553.002
+references:
+    - https://attack.mitre.org/techniques/T1553/002/
+sample-evtx: 
+logsource: sysmon
+ruletype: Hayabusa


### PR DESCRIPTION
最近話題になっている流出されたNVIDIA証明証に署名されたマルウェア等を検知するため。