### PR TITLE
fixed test_files rule id #22

### DIFF
--- a/config/exclude_rules.txt
+++ b/config/exclude_rules.txt
@@ -20,4 +20,4 @@ db809f10-56ce-4420-8c86-d6a7d793c79c # "Raw Disk Access Using Illegitimate Tools
 0eb2107b-a596-422e-b123-b389d5594ed7 # "Hurricane Panda Activity"
 
 # Test File
-000000000-0000-0000-0000-000000000000
+00000000-0000-0000-0000-000000000000 # TestFile

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0001.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0001.yml
@@ -9,7 +9,7 @@ detection:
   condition: SELECTION_1
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0002.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0002.yml
@@ -18,7 +18,7 @@ detection:
   condition: (SELECTION_1 and SELECTION_2 and SELECTION_3 and SELECTION_4 and SELECTION_5)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0003.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0003.yml
@@ -18,7 +18,7 @@ detection:
   condition: ((SELECTION_1 or SELECTION_2 or SELECTION_3 or SELECTION_4) and SELECTION_5)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0004.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0004.yml
@@ -16,7 +16,7 @@ detection:
   condition: ((SELECTION_1) and (SELECTION_2 or SELECTION_3))
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0005.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0005.yml
@@ -18,7 +18,7 @@ detection:
   condition: ((SELECTION_1) and (SELECTION_2 and SELECTION_3 and SELECTION_4))
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0006.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0006.yml
@@ -12,7 +12,7 @@ detection:
   condition: (SELECTION_1 or SELECTION_2)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0007.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0007.yml
@@ -12,7 +12,7 @@ detection:
   condition: (SELECTION_1 or SELECTION_2)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0008.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0008.yml
@@ -12,7 +12,7 @@ detection:
   condition: (SELECTION_1 and SELECTION_2)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0009.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0009.yml
@@ -18,7 +18,7 @@ detection:
   condition: (SELECTION_1 and SELECTION_2 and SELECTION_3 and SELECTION_4 and SELECTION_5)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0010.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0010.yml
@@ -27,7 +27,7 @@ detection:
     and SELECTION_6 and SELECTION_7 and SELECTION_8) or SELECTION_9)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0011.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0011.yml
@@ -25,7 +25,7 @@ detection:
     SELECTION_5) or (SELECTION_6 and SELECTION_7)) and SELECTION_8)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0012.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0012.yml
@@ -23,7 +23,7 @@ detection:
     and SELECTION_6 and SELECTION_7)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0013.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0013.yml
@@ -23,7 +23,7 @@ detection:
     or (SELECTION_6 and SELECTION_7))
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0014.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0014.yml
@@ -11,7 +11,7 @@ detection:
   timeflame: 2d
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0015.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0015.yml
@@ -17,7 +17,7 @@ detection:
   timeflame: 2d
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0016.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0016.yml
@@ -17,7 +17,7 @@ detection:
   timeflame: 2d
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0017.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0017.yml
@@ -17,7 +17,7 @@ detection:
   timeflame: 2d
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0018.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0018.yml
@@ -19,7 +19,7 @@ detection:
     SELECTION_5)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0019.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0019.yml
@@ -10,7 +10,7 @@ detection:
   condition: ' not (SELECTION_1)'
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0020.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0020.yml
@@ -19,7 +19,7 @@ detection:
     SELECTION_4)))) and SELECTION_5)
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0021.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0021.yml
@@ -12,7 +12,7 @@ detection:
   condition: (SELECTION_1 and  not (SELECTION_2)) | count() < 3
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/expected_rules/test_rules/test0022.yml
+++ b/tools/sigmac/test_files/expected_rules/test_rules/test0022.yml
@@ -12,7 +12,7 @@ detection:
   condition: (SELECTION_1 and  not (SELECTION_2)) | count(TEAMNAME) by HOGE < 3
 falsepositives:
 - Unknown
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 level: medium
 logsource:
   product: windows

--- a/tools/sigmac/test_files/test_rules/test0001.yml
+++ b/tools/sigmac/test_files/test_rules/test0001.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     simple test
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0002.yml
+++ b/tools/sigmac/test_files/test_rules/test0002.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     map test and escape str test and empty string test and null test
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0003.yml
+++ b/tools/sigmac/test_files/test_rules/test0003.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     list test
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0004.yml
+++ b/tools/sigmac/test_files/test_rules/test0004.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     list test
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0005.yml
+++ b/tools/sigmac/test_files/test_rules/test0005.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     all modifier
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0006.yml
+++ b/tools/sigmac/test_files/test_rules/test0006.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     contains modifier
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0007.yml
+++ b/tools/sigmac/test_files/test_rules/test0007.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     endswith pipe modifier and startswith pipe modifier
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0008.yml
+++ b/tools/sigmac/test_files/test_rules/test0008.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     base64 encode modifier
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0009.yml
+++ b/tools/sigmac/test_files/test_rules/test0009.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     re modifier test
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0010.yml
+++ b/tools/sigmac/test_files/test_rules/test0010.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     all of test
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0011.yml
+++ b/tools/sigmac/test_files/test_rules/test0011.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     1 of
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0012.yml
+++ b/tools/sigmac/test_files/test_rules/test0012.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     all of them
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0013.yml
+++ b/tools/sigmac/test_files/test_rules/test0013.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     1 of them
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0014.yml
+++ b/tools/sigmac/test_files/test_rules/test0014.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     timeflame 
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0015.yml
+++ b/tools/sigmac/test_files/test_rules/test0015.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     condition and or
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0016.yml
+++ b/tools/sigmac/test_files/test_rules/test0016.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     condition and
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0017.yml
+++ b/tools/sigmac/test_files/test_rules/test0017.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     condition or
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0018.yml
+++ b/tools/sigmac/test_files/test_rules/test0018.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     () 
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0019.yml
+++ b/tools/sigmac/test_files/test_rules/test0019.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     condition not
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0020.yml
+++ b/tools/sigmac/test_files/test_rules/test0020.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     condition not ()
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0021.yml
+++ b/tools/sigmac/test_files/test_rules/test0021.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     condition count
 status: experimental

--- a/tools/sigmac/test_files/test_rules/test0022.yml
+++ b/tools/sigmac/test_files/test_rules/test0022.yml
@@ -1,5 +1,5 @@
 title: test
-id: 000000000-0000-0000-0000-000000000000
+id: 00000000-0000-0000-0000-000000000000
 description: |
     condition count
 status: experimental


### PR DESCRIPTION
fixed #22 

## What Changed
- Fixed test rule files ID in tools/sigmac
  - Right ID fomat is {8}-{4}-{4}-{4}-{12} but test id format was {9}-{4}-{4}-{4}-{11}.