### PR TITLE
removed test rule line from level_tuning.txt

### DIFF
--- a/config/level_tuning.txt
+++ b/config/level_tuning.txt
@@ -1,5 +1,4 @@
 id,new_level
-00000000-0000-0000-0000-000000000000,informational # sample level tuning line
 fdb62a13-9a81-4e5c-a38f-ea93a16f6d7c,medium # "Encoded FromBase64String". Originally critical.
 61a7697c-cb79-42a8-a2ff-5f0cdfae0130,high # "CobaltStrike Service Installations in Registry". Originally critical.
 36803969-5421-41ec-b92f-8500f79c23b0,low # "Detects persistence registry keys". Originally critical. Changed to low due to a high possibility of false positives.


### PR DESCRIPTION
https://github.com/Yamato-Security/hayabusa/pull/512 の対応で level_tuning.txtにテストファイル用の内容が入っていると--level-tuning実行時にテストファイルもチューニング対象となってしまうため削除しました