### PR TITLE
provider name alias fix

### DIFF
--- a/config/eventkey_alias.txt
+++ b/config/eventkey_alias.txt
@@ -129,8 +129,8 @@ ProcessName,Event.EventData.ProcessName
 Product,Event.EventData.Product
 Properties,Event.EventData.Properties
 Provider,Event.UserData.Provider
-ProviderName,Event.System.Provider_Name
-Provider_Name,Event.System.Provider_Name
+ProviderName,Event.System.Provider_attributes.Name
+Provider_Name,Event.System.Provider_attributes.Name
 QNAME,Event.EventData.QNAME
 query,Event.EventData.Query
 Query,Event.UserData.Query
@@ -203,7 +203,6 @@ Workstation,Event.EventData.Workstation
 WorkstationName,Event.EventData.WorkstationName
 param1,Event.EventData.param1
 param2,Event.EventData.param2
-provider_Name,Event.EventData.Provider_Name
 service,Event.EventData.Service
 sha1,Event.EventData.Hashes_sha1
 UserDataProviderName,Event.UserData.Operation_StartedOperational.ProviderName


### PR DESCRIPTION
`Provider Name`が正しく定義されていませんでした。
sample-evtxに対して、
Before:
```
Unique detections: 503
```

After:
```
Unique detections: 517
```

`Channel`ではなく、`Provider Name`を使っているsigmaルールが多い(約70件)ので、検知率が大分上がるはずです。