### PR TITLE
Add: exclude_rule_list function

### DIFF
--- a/tools/sigmac/convert.py
+++ b/tools/sigmac/convert.py
@@ -17,7 +17,7 @@ EXPORT_DIR_NAME = "./hayabusa_rules"
 RULES_DIR = "./rules/windows"
 CPU = None
 IGNORE_CONFIGS = {"windows-services.yml", "powershell.yml"}
-EXCLUDE_RULE_FILE = set()
+EXCLUDE_CATEGORY = {"file_rename"}
 SUPPRESSION = False
 
 FORMAT = ('[%(levelname)-8s] %(message)s')
@@ -108,6 +108,9 @@ class Logconverter():
                 logger.warning(rule_path + " has no log category description.")
 
         logger.debug("target: " + file_name)
+        if category in EXCLUDE_CATEGORY:
+            logger.info(file_name + " has CATEGORY hayabusa couldn't use.")
+            return convert_datas
         if category in self.config_map:
             configs = copy.deepcopy(self.config_map[category])
         else:

--- a/tools/sigmac/convert.py
+++ b/tools/sigmac/convert.py
@@ -16,7 +16,8 @@ SIGMAC_DIR = "./tools/"
 EXPORT_DIR_NAME = "./hayabusa_rules"
 RULES_DIR = "./rules/windows"
 CPU = None
-IGNORE_CONFIGS = ["windows-services.yml", "powershell.yml"]
+IGNORE_CONFIGS = {"windows-services.yml", "powershell.yml"}
+EXCLUDE_RULE_FILE = set()
 SUPPRESSION = False
 
 FORMAT = ('[%(levelname)-8s] %(message)s')
@@ -87,7 +88,7 @@ class Logconverter():
             file_path = os.path.join(rules_dir, file)
             if os.path.isdir(file_path):
                 convert_datas.extend(self.create_rule_list(file_path))
-            elif file.endswith(".yml"):
+            elif file.endswith(".yml") and not file in EXCLUDE_RULE_FILE:
                 convert_datas.extend(self.create_convert_command(file_path, file))
         return convert_datas
 
@@ -201,6 +202,8 @@ if __name__ == "__main__":
     parser.add_argument("-o", "--output",
                         help="Export directory. Default: ./hayabusa_rules",
                         default="./hayabusa_rules")
+    parser.add_argument("--exclude-rule-list",
+                        help="Specify a exclude-rule-list.txt file")
     parser.add_argument("--debug", help="Debug mode.",
                     action="store_true")
     parser.add_argument("--verbose", help="Show more information",
@@ -233,5 +236,14 @@ if __name__ == "__main__":
         if not os.path.isdir(RULES_DIR):
             logger.error(args.rule_path + " does not exist.")
             sys.exit(1)
+
+    # SET EXCLUDE RULEs
+    if args.exclude_rule_list:
+        try:
+            with open(args.exclude_rule_list, 'r') as f:
+                for line in f:
+                    EXCLUDE_RULE_FILE.add(line.strip())
+        except Exception as e:
+            logger.error("Failed to read exclude_rule_list file: " + e)
 
     main()

--- a/tools/sigmac/convert.py
+++ b/tools/sigmac/convert.py
@@ -88,7 +88,7 @@ class Logconverter():
             file_path = os.path.join(rules_dir, file)
             if os.path.isdir(file_path):
                 convert_datas.extend(self.create_rule_list(file_path))
-            elif file.endswith(".yml") and not file in EXCLUDE_RULE_FILE:
+            elif file.endswith(".yml"):
                 convert_datas.extend(self.create_convert_command(file_path, file))
         return convert_datas
 
@@ -202,8 +202,6 @@ if __name__ == "__main__":
     parser.add_argument("-o", "--output",
                         help="Export directory. Default: ./hayabusa_rules",
                         default="./hayabusa_rules")
-    parser.add_argument("--exclude-rule-list",
-                        help="Specify a exclude-rule-list.txt file")
     parser.add_argument("--debug", help="Debug mode.",
                     action="store_true")
     parser.add_argument("--verbose", help="Show more information",
@@ -236,14 +234,5 @@ if __name__ == "__main__":
         if not os.path.isdir(RULES_DIR):
             logger.error(args.rule_path + " does not exist.")
             sys.exit(1)
-
-    # SET EXCLUDE RULEs
-    if args.exclude_rule_list:
-        try:
-            with open(args.exclude_rule_list, 'r') as f:
-                for line in f:
-                    EXCLUDE_RULE_FILE.add(line.strip())
-        except Exception as e:
-            logger.error("Failed to read exclude_rule_list file: " + e)
 
     main()

--- a/tools/sigmac/exclude_rule_list.txt
+++ b/tools/sigmac/exclude_rule_list.txt
@@ -1,2 +1,0 @@
-file_rename_win_not_dll_to_dll.yml
-file_rename_win_ransomware.yml

--- a/tools/sigmac/exclude_rule_list.txt
+++ b/tools/sigmac/exclude_rule_list.txt
@@ -1,0 +1,2 @@
+file_rename_win_not_dll_to_dll.yml
+file_rename_win_ransomware.yml


### PR DESCRIPTION
https://github.com/Yamato-Security/hayabusa-rules/pull/92#issuecomment-1221190253 にてルール変換しない機能が欲しいとの要望に応えて実装。

exclude-rule-list に不要なルールを記載、オプション(`--exclude-rule-list <作成したリストへのパス>`)をつけると変換されなくなる。

```sh
❯ python3 convert.py -r rules/windows.bak --exclude-rule-list ../../Yamato-Security/hayabusa-rules/tools/sigmac/exclude_rule_list.txt --debug
Converting rules. Please wait.
0 rules where converted! (failed: 0)
```

Hayabusa側の [exclude_rules.txt](https://github.com/Yamato-Security/hayabusa-rules/blob/main/config/exclude_rules.txt) で実装があるためそちら側を利用するかこちらも入れるか。
機能がかぶっておりあくまでメインはHayabusaなのでconvertの機能としては変換スクリプトがどんどん汎用性のないものになってしまうためいれなくてもいいと思っている。