### PR TITLE
Feature/fix GitHub action

### DIFF
--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -47,18 +47,14 @@ jobs:
           pip install -r requirements.txt
           rm requirements.txt
 
-      # - name: Update sigma rules
-      #   run: |
-      #     pushd sigma-repo
-      #     python3 convert.py --suppression
-      #     popd
-      #     rm -rf hayabusa-rules/sigma/
-      #     mkdir hayabusa-rules/sigma/
-      #     cp -r sigma-repo/hayabusa_rules/* hayabusa-rules/sigma/
-
       - name: Update sigma rules
         run: |
-          rm -r hayabusa-rules/sigma/sysmon/create_remote_thread
+          pushd sigma-repo
+          python3 convert.py --suppression
+          popd
+          rm -rf hayabusa-rules/sigma/
+          mkdir hayabusa-rules/sigma/
+          cp -r sigma-repo/hayabusa_rules/* hayabusa-rules/sigma/
 
       - name: Create Text
         id: create-text
@@ -95,19 +91,19 @@ jobs:
           commit-message: Sigma Rule Update (${{ env.action_date }})
           branch: rules/auto-sigma-update
           delete-branch: true
-          title: '[Auto] Sigma Update report(${{ env.action_date }})' ### If the PR which have the same name have already existed, this github action library will not create new pull request but it will update the PR that have the same name. Therefore I add the date to the pull request's title.
+          title: '[Auto] Sigma Update report(${{ env.action_date }})' ### If the PR with the same name have already existed, this github action library will not create new pull request but it will update the PR with the same name. Therefore I add the date to the pull request's title not to update existed PR.
           body: |
             ${{ env.action_date }} Update report
           assignees: itiB
           reviewers: itiB
 
-      # - name: Enable Pull Request Automerge
-      #   if: steps.cpr.outputs.pull-request-operation == 'created'
-      #   uses: peter-evans/enable-pull-request-automerge@v1
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-      #     merge-method: squash
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash
 
       - name: upload change log
         if: env.change_exist == 'true'

--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -100,7 +100,6 @@ jobs:
             ${{ env.action_date }} Update report
           assignees: itiB
           reviewers: itiB
-          branch-suffix: timestamp
 
       # - name: Enable Pull Request Automerge
       #   if: steps.cpr.outputs.pull-request-operation == 'created'

--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -47,20 +47,24 @@ jobs:
           pip install -r requirements.txt
           rm requirements.txt
 
+      # - name: Update sigma rules
+      #   run: |
+      #     pushd sigma-repo
+      #     python3 convert.py --suppression
+      #     popd
+      #     rm -rf hayabusa-rules/sigma/
+      #     mkdir hayabusa-rules/sigma/
+      #     cp -r sigma-repo/hayabusa_rules/* hayabusa-rules/sigma/
+
       - name: Update sigma rules
         run: |
-          pushd sigma-repo
-          python3 convert.py --suppression
-          popd
-          rm -rf hayabusa-rules/sigma/
-          mkdir hayabusa-rules/sigma/
-          cp -r sigma-repo/hayabusa_rules/* hayabusa-rules/sigma/
+          rm -r hayabusa-rules/sigma/sysmon/create_remote_thread
 
       - name: Create Text
         id: create-text
         run: |
           pushd hayabusa-rules
-          echo "action_date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+          echo "action_date=$(date '+%Y-%m-%d  %H:%M:%S')" >> $GITHUB_ENV
           echo "change_exist=true" >> $GITHUB_ENV
           git_new=$(git diff --name-status --diff-filter=AC)
           git_mod=$(git diff --name-status --diff-filter=MR)
@@ -91,19 +95,20 @@ jobs:
           commit-message: Sigma Rule Update (${{ env.action_date }})
           branch: rules/auto-sigma-update
           delete-branch: true
-          title: '[Auto] Sigma Update report'
+          title: '[Auto] Sigma Update report(${{ env.action_date }})' ### If the PR which have the same name have already existed, this github action library will not create new pull request but it will update the PR that have the same name. Therefore I add the date to the pull request's title.
           body: |
             ${{ env.action_date }} Update report
           assignees: itiB
           reviewers: itiB
+          branch-suffix: timestamp
 
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
+      # - name: Enable Pull Request Automerge
+      #   if: steps.cpr.outputs.pull-request-operation == 'created'
+      #   uses: peter-evans/enable-pull-request-automerge@v1
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+      #     merge-method: squash
 
       - name: upload change log
         if: env.change_exist == 'true'


### PR DESCRIPTION
@itiB 
すいません、前回のgithub actionのファイルだと、pull requestが正しく作られない問題があるようです。原因としては既存のpull requestと同じtitleを指定した場合、新規にpull requestが作られず既存のpull requestに更新されるような動きになるようです。既存のpull requestは既にclose済みで正しくauto merge出来ていないような感じでした。

あとslackにも書いたのですが、そもそもauto mergeして良いか分かってないです。もし、auto mergeしないなら、その部分のコメントアウトした上でこのpull requestをapprove/mergeしてもらえればと思います。

closes #96 