### PR TITLE
fix: sigma command subprocess deadlock when child process output a lot of texts. 

### DIFF
--- a/tools/sigmac/convert.py
+++ b/tools/sigmac/convert.py
@@ -167,9 +167,9 @@ def sigma_executer(data: ConvertData):
     proc = subprocess.Popen(data.sigma_command,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
-        proc.wait(60)
+        outs, errs = proc.communicate(timeout=60)
         logger.info(data.file_name + " were converted.")
-        stderr = proc.stderr.read().decode("utf-8")
+        stderr = errs.decode("utf-8")
         if len(stderr) > 0:
             if SUPPRESSION and "An unsupported feature is required for this Sigma rule" in stderr:
                 # Suppress Option
@@ -181,7 +181,7 @@ def sigma_executer(data: ConvertData):
                            + stderr)
             return 1
         with open(data.output_path, mode="w") as f:
-            f.write(proc.stdout.read().decode("utf-8"))
+            f.write(outs.decode("utf-8"))
     except subprocess.TimeoutExpired:
         logger.error("Timeout Expired, failed to convert " + data.output_path
                     + "\n" + "Command: " + data.sigma_command)


### PR DESCRIPTION
## What Changed
- fix: #150
- change  sigma command execution function [Popen.wait](https://docs.python.org/3.10/library/subprocess.html#subprocess.Popen.wait) to [Popen.communicate](https://docs.python.org/3.10/library/subprocess.html#subprocess.Popen.communicate)
  - because Popen.wait() cause deadlock when child process output a lot of texts.

## Evidence
### Test Environment
- Python 3.10.6
- macOS Monterey version 12.6
- MacBook Air (M1, 2020)
### Test procedure
Do the following, 
1. git clone https://github.com/SigmaHQ/sigma.git
2. move ./rules/windows/driver_load/driver_load_vuln_drivers.yml  to another directory.
3. python3 convert.py (before fix) ... 3004 file converted.
4. move hayabusa_rules hayabusa_rules_bug 
5. move ./rules/windows/driver_load/driver_load_vuln_drivers.yml to the original directory.
6. python3 convert.py (after fix) ... 3005 file converted.
7. move hayabusa_rules hayabusa_rules_fix 

then compare hayabusa_rules_bug with hayabusa_rules_fix as follows.
Confirm that there is no difference other than driver_load_vuln_drivers.yml.
```
fukusuke@fukusukenoAir Python % diff -rq hayabusa_rules_bug hayabusa_rules_fix
Only in hayabusa_rules_fix/sysmon/driver_load: driver_load_vuln_drivers.yml
fukusuke@fukusukenoAir Python % find ./hayabusa_rules_bug -type f | wc -l
    3004
fukusuke@fukusukenoAir Python % find ./hayabusa_rules_fix -type f | wc -l
    3005
```

Attach a set of conversion files of the sigma repository after fix.
[hayabusa_rules_fix.zip](https://github.com/Yamato-Security/hayabusa-rules/files/9788375/hayabusa_rules_fix.zip)

I would appreciate it if you could review🙏
