### PR TITLE
fix: convert.py fails if one rule times out

### DIFF
--- a/tools/sigmac/convert.py
+++ b/tools/sigmac/convert.py
@@ -184,7 +184,7 @@ def sigma_executer(data: ConvertData):
             f.write(outs.decode("utf-8"))
     except subprocess.TimeoutExpired:
         logger.error("Timeout Expired, failed to convert " + data.output_path
-                    + "\n" + "Command: " + data.sigma_command)
+                    + "\n" + "Command: " + str(data.sigma_command))
         proc.kill()
         return 1
     except Exception as err:


### PR DESCRIPTION
## What Changed
- fix: #151
- fixed string concatenation in TimeoutExpired catch block.

## Evidence
### Test Environment
- Python 3.10.6
- macOS Monterey version 12.6
- MacBook Air (M1, 2020)
### Test Procedure
1. [Execute the reproduction procedure described in #151](https://github.com/Yamato-Security/hayabusa-rules/issues/151#issuecomment-1279675529) (Put the two yml files in the rules directory)
2. convert.py not failed and output is as follows.
```
python3 convert.py
Converting rules. Please wait.
[ERROR   ] Timeout Expired, failed to convert ./hayabusa_rules/builtin/win_av_relevant_match.yml
Command: ['python3', './tools/sigmac', '-t', 'hayabusa', '-c', './tools/config/generic/windows-services.yml', '--defer-abort', './rules/windows/win_av_relevant_match.yml']
[ERROR   ] Timeout Expired, failed to convert ./hayabusa_rules/builtin/win_audit_cve.yml
Command: ['python3', './tools/sigmac', '-t', 'hayabusa', '-c', './tools/config/generic/windows-services.yml', '--defer-abort', './rules/windows/win_audit_cve.yml']
0 rules where converted! (failed: 2)
```

I would appreciate it if you could review🙏