### PR TITLE
update action versions

### DIFF
--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: clone hayabusa rule repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: hayabusa-rules
 
       - name: clone sigmac
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: SigmaHQ/sigma
           path: sigma-repo # It is necessary to specify the path because hayabusa-rules repository have the folder which has the same name.
@@ -98,7 +98,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v1
+        uses: peter-evans/enable-pull-request-automerge@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: upload change log
         if: env.change_exist == 'true'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: changed_rule_log
           path: ${{ github.workspace }}/changed_rule.logs


### PR DESCRIPTION
Closes #152 

Actionをバージョンアップしたら、古いNode.jsの警告で出なくなりました。

<img width="1028" alt="Screen Shot 2022-10-18 at 8 31 56" src="https://user-images.githubusercontent.com/71482215/196302864-6e69718c-642e-4dc1-be0b-a0edaab5eadb.png">
