### PR TITLE
update readme EventData change to Data

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -459,14 +459,14 @@ detection:
 
 ## パイプ
 
-イベントキーにはパイプを指定することができます。ここまで説明した書き方では完全一致しか表現できませんでしたが、パイプを使うことでより柔軟な検知ルールを記載できるようになります。以下の例では、`Data`の値が正規表現 `[\s\S]*EngineVersion=2.0[\s\S]*` に当てはまる場合、条件にマッチすることになります。
+イベントキーにはパイプを指定することができます。ここまで説明した書き方では完全一致しか表現できませんでしたが、パイプを使うことでより柔軟な検知ルールを記載できるようになります。以下の例では、ある`Data`フィールドの値に`EngineVersion=2`という文字列が入っている場合、条件にマッチすることになります。
 
 ```yaml
 detection:
     selection:
-        Channel: Microsoft-Windows-PowerShell/Operational
+        Channel: 'Windows PowerShell'
         EventID: 400
-        Data|re: '[\s\S]*EngineVersion=2\.0[\s\S]*'
+        Data|contains: 'EngineVersion=2'
     condition: selection
 ```
 

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -405,7 +405,7 @@ Windowsのイベントログは、基本データ（イベントID、タイム�
 </Event>
 ```
 
-この問題に対処するため、`Data`タグの`Name`属性に指定された値をイベントキーとして利用できます。例えば、EventData の `SubjectUserName` と `SubjectDomainName` を条件として利用する場合、以下のように記述することが可能です。
+この問題に対処するため、`Data`タグの`Name`属性に指定された値をイベントキーとして利用できます。例えば、`EventData`の`SubjectUserName`と`SubjectDomainName` を条件として利用する場合、以下のように記述することが可能です。
 
 ```yaml
 detection:
@@ -419,7 +419,7 @@ detection:
 
 ### EventDataの例外的なパターン
 
-`EventData` タグにネストされたいくつかのタグは `Name` 属性を持ちません。
+`EventData`タグにネストされたいくつかのタグは`Name`属性を持ちません。
 
 ```xml
 <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
@@ -436,14 +436,14 @@ detection:
 </Event>
 ```
 
-上記のようなイベントログを検知するには、`EventData`というイベントキーを指定します。この場合、`EventData`にネストされたタグの内、`Data`フィールドが`None`になっている場合は、条件にマッチすることになります。
+上記のようなイベントログを検知するには、`Data`というイベントキーを指定します。この場合、`EventData`にネストされたタグの内、`Data`フィールドが`None`になっている場合は、条件にマッチすることになります。
 
 ```yaml
 detection:
     selection:
         Channel: Security
         EventID: 5379
-        EventData: None
+        Data: None
     condition: selection
 ```
 
@@ -459,14 +459,14 @@ detection:
 
 ## パイプ
 
-イベントキーにはパイプを指定することができます。ここまで説明した書き方では完全一致しか表現できませんでしたが、パイプを使うことでより柔軟な検知ルールを記載できるようになります。以下の例では、`EventData`の値が正規表現 `[\s\S]*EngineVersion=2.0[\s\S]*` に当てはまる場合、条件にマッチすることになります。
+イベントキーにはパイプを指定することができます。ここまで説明した書き方では完全一致しか表現できませんでしたが、パイプを使うことでより柔軟な検知ルールを記載できるようになります。以下の例では、`Data`の値が正規表現 `[\s\S]*EngineVersion=2.0[\s\S]*` に当てはまる場合、条件にマッチすることになります。
 
 ```yaml
 detection:
     selection:
         Channel: Microsoft-Windows-PowerShell/Operational
         EventID: 400
-        EventData|re: '[\s\S]*EngineVersion=2\.0[\s\S]*'
+        Data|re: '[\s\S]*EngineVersion=2\.0[\s\S]*'
     condition: selection
 ```
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Some of the tags nested in `EventData` do not have a `Name` attribute.
 </Event>
 ```
 
-To detect an event log like the one above, you can specify an eventkey named `EventData`.
+To detect an event log like the one above, you can specify an eventkey named `Data`.
 In this case, the condition will match as long as any one of the nested `Data` tags equals `None`.
 
 ```yaml
@@ -442,7 +442,7 @@ detection:
     selection:
         Channel: Security
         EventID: 5379
-        EventData: None
+        Data: None
     condition: selection
 ```
 
@@ -458,14 +458,14 @@ If you want to print out just the first `Data` field data, you can specify `%Dat
 
 ## Pipes
 
-A pipe can be used with eventkeys as shown below for matching strings. All of the conditions we have described so far use exact matches, but by using pipes, you can describe more flexible detection rules. In the following example, if the value of `EventData` matches the regular expression `[\s\S]*EngineVersion=2\.0[\s\S]*`, it will match the condition.
+A pipe can be used with eventkeys as shown below for matching strings. All of the conditions we have described so far use exact matches, but by using pipes, you can describe more flexible detection rules. In the following example, if the value of `Data` matches the regular expression `[\s\S]*EngineVersion=2\.0[\s\S]*`, it will match the condition.
 
 ```yaml
 detection:
     selection:
         Channel: Microsoft-Windows-PowerShell/Operational
         EventID: 400
-        EventData|re: '[\s\S]*EngineVersion=2\.0[\s\S]*'
+        Data|re: '[\s\S]*EngineVersion=2\.0[\s\S]*'
     condition: selection
 ```
 

--- a/README.md
+++ b/README.md
@@ -458,14 +458,14 @@ If you want to print out just the first `Data` field data, you can specify `%Dat
 
 ## Pipes
 
-A pipe can be used with eventkeys as shown below for matching strings. All of the conditions we have described so far use exact matches, but by using pipes, you can describe more flexible detection rules. In the following example, if the value of `Data` matches the regular expression `[\s\S]*EngineVersion=2\.0[\s\S]*`, it will match the condition.
+A pipe can be used with eventkeys as shown below for matching strings. All of the conditions we have described so far use exact matches, but by using pipes, you can describe more flexible detection rules. In the following example, if a value of `Data` contains the string  `EngineVersion=2`, it will match the condition.
 
 ```yaml
 detection:
     selection:
-        Channel: Microsoft-Windows-PowerShell/Operational
+        Channel: 'Windows PowerShell'
         EventID: 400
-        Data|re: '[\s\S]*EngineVersion=2\.0[\s\S]*'
+        Data|contains: 'EngineVersion=2'
     condition: selection
 ```
 


### PR DESCRIPTION
Hayabusa now uses `Data` instead of `EventData` to check `Data` fields. The same as sigma.