### PR TITLE
stop regex conversion

### DIFF
--- a/tools/sigmac/hayabusa.py
+++ b/tools/sigmac/hayabusa.py
@@ -76,49 +76,7 @@ class HayabusaBackend(SingleTextQueryBackend):
         # `|re`オプションに対応
         if type(value) == SigmaRegularExpressionModifier:
             fieldname = fieldname + "|re"
-
-            # pythonとかの正規表現では/(スラッシュ)や"(ダブルクオート)をエスケープしてもエラーが出ないが、Rustの正規表現エンジンではスラッシュやダブルクオートをエスケープするとエラーが出てしまう
-            # そこでスラッシュやダブルクオートのエスケープは消しておく。
-            # あと、この実装は結構怪しいので、将来バージョンではこの実装を無くして、hayabusa側で使用する正規表現エンジンを普通のpythonとかで使われているやつに変えた方がいいと思う。
-            regex_value = value.value.replace('\/', '/')
-            regex_value = regex_value.replace("\\\"", "\"")
-
-            # 追加のケースとして、pythonとかの正規表現では{はエスケープ不要だが、Rustでは必要なので、それを修正するためのコード。めんどい
-            idx = 0
-            prev_regex = regex_value
-            regex_value = ""
-            while idx < len(prev_regex):
-                # 既にエスケープされているものはスキップする。
-                if prev_regex[idx:idx+2] == "\\{" or prev_regex[idx:idx+2] == "\\}":
-                    regex_value += prev_regex[idx:idx+2]
-                    idx += 2
-                    continue
-
-                ch = prev_regex[idx]
-                # エスケープ不要な}はここに来ないように、以降の処理でidxを調整している。なのでここにくる}はエスケープが必要。
-                if ch == "}":
-                    regex_value += "\\}"
-                    idx += 1
-                    continue
-
-                # {じゃない場合はそのまま足すだけ
-                if ch != "{":
-                    regex_value += ch
-                    idx += 1
-                    continue
-
-                # {の場合の処理
-                reg_match = SPECIAL_REGEX.match(prev_regex[idx:])
-                if reg_match == None:
-                    # 文字列としての{なので、エスケープ必要
-                    regex_value += "\\{"
-                    idx += 1
-                else:
-                    # これは桁数を指定する{なので、エスケープ不要で}までidxをスキップ
-                    regex_value += reg_match.group()
-                    idx += len(reg_match.group())
-
-            return self.generateNode((fieldname, regex_value))
+            return self.generateNode((fieldname, value.value))
         else:
             raise NotImplementedError(
                 "Type modifier '{}' is not supported by backend".format(value.identifier))


### PR DESCRIPTION
先程、Hayabusa 1.8.1でルールを更新したら、６件のパースエラーが出ていました。
調べたら、上流のSigmaリポで正規表現を直したので、変換スクリプトで`|re`の変換が悪さをしているみたいなので、正規表現をそのまま渡すようにしたいです。(1.8.1をv2のブランチでかけたら、パースエラー出ませんでした。）
以前に高橋さんが`|re`のコード修正のようにhayabusa.pyを修正してみましたが、念の為、確認をお願いできますか？