### PR TITLE
fix: keep Sigma YAML `null` value as is

### DIFF
--- a/tools/sigmac/hayabusa.py
+++ b/tools/sigmac/hayabusa.py
@@ -66,8 +66,9 @@ class HayabusaBackend(SingleTextQueryBackend):
         elif isinstance(value, SigmaTypeModifier):
             return self.generateMapItemTypedNode(transformed_fieldname, value)
         elif value is None:
-            # nullは正規表現で表す。これでいいのかちょっと不安
-            return self.generateNode((transformed_fieldname+"|re", "^$"))
+            name = self.create_new_selection()
+            self.name_2_selection[name] = [(transformed_fieldname, None)]
+            return name
         else:
             raise TypeError(
                 "Backend does not support map values of type " + str(type(value)))
@@ -261,7 +262,7 @@ class HayabusaBackend(SingleTextQueryBackend):
                         ## is_keyword_list() == Falseの場合
                         parsed_yaml["detection"][key][fieldname] = value
 
-            yaml.dump(parsed_yaml, bs, indent=4, default_flow_style=False)
+            yaml.safe_dump(parsed_yaml, bs, indent=4, default_flow_style=False)
             ret = bs.getvalue()
 
         return ret

--- a/tools/sigmac/hayabusa.py
+++ b/tools/sigmac/hayabusa.py
@@ -9,8 +9,6 @@ from sigma.parser.condition import SigmaAggregationParser, ConditionOR, Conditio
 from sigma.parser.modifiers.base import SigmaTypeModifier
 from sigma.parser.modifiers.type import SigmaRegularExpressionModifier
 
-SPECIAL_REGEX = re.compile("^\{(\d)+,?(\d+)?\}")
-
 
 class HayabusaBackend(SingleTextQueryBackend):
     """Base class for backends that generate one text-based expression from a Sigma rule"""


### PR DESCRIPTION
## What Changed
- fixed: #241 
  - If the YAML value is `null`, do not convert it to `|re: ^$` (pass `None` as is)
  - changed  output function`yaml.dump()` to `yaml.safe_dump()`  
    - because `yaml.dump()` doesn't output `null` value (if passed `None`, output nothing)
## Evidence
### Test Environment
- Python 3.11.0
- macOS Ventura version 13.0.1 (MacBook Air (M1, 2020))

### Test 1
Compared the command results below,
`python3 ./tools/sigmac -t hayabusa -c ./tools/config/generic/windows-audit.yml -c ./tools/config/generic/windows-services.yml rules/windows/process_creation/proc_creation_win_proc_wrong_parent.yml > test.yml`

diff results is as follows.
```
sigma % diff test.yml test-dev.yml
37c37
<         ParentProcessName|re: ^$
---
>         ParentProcessName: null
```

### Test 2
Confirmed that no unnecessary diffs before and after fix. [Here is full diff](https://github.com/Yamato-Security/hayabusa-rules/files/10217097/diff.txt)
- except for the following two points
  1.   `|re: ^$` -> `null`
  2.  `description` texts new line positions. 

### Test 3
Confirmed that the number of files that fail to convert(`convert.py`) does not change before and after fix.
(The following 17 files fail)
```
[WARNING ] Conversion of "image_load_mimikatz_inmemory_detection.yml" failed.
[WARNING ] Conversion of "sysmon_wmi_susp_encoded_scripts.yml" failed.
[WARNING ] Conversion of "proc_creation_win_apt_turla_commands_medium.yml" failed.
[WARNING ] Conversion of "proc_creation_win_apt_turla_commands_medium.yml" failed.
[WARNING ] Conversion of "proc_creation_win_powershell_defender_disable_feature.yml" failed.
[WARNING ] Conversion of "proc_creation_win_powershell_defender_disable_feature.yml" failed.
[WARNING ] Conversion of "proc_creation_win_encoded_frombase64string.yml" failed.
[WARNING ] Conversion of "proc_creation_win_encoded_frombase64string.yml" failed.
[WARNING ] Conversion of "proc_creation_win_encoded_iex.yml" failed.
[WARNING ] Conversion of "proc_creation_win_encoded_iex.yml" failed.
[WARNING ] Conversion of "proc_creation_win_apt_silence_downloader_v3.yml" failed.
[WARNING ] Conversion of "proc_creation_win_apt_silence_downloader_v3.yml" failed.
[WARNING ] Conversion of "proc_creation_win_powershell_defender_base64.yml" failed.
[WARNING ] Conversion of "proc_creation_win_powershell_defender_base64.yml" failed.
[WARNING ] Conversion of "win_security_cobaltstrike_service_installs.yml" failed.
[WARNING ] Conversion of "win_system_cobaltstrike_service_installs.yml" failed.
[WARNING ] Conversion of "win_security_susp_samr_pwset.yml" failed.
3138 rules where converted! (failed: 17)
```
I would appreciate it if you could review🙏