### PR TITLE
add provider abbreviation config files

### DIFF
--- a/config/generic_abbreviations.txt
+++ b/config/generic_abbreviations.txt
@@ -1,0 +1,13 @@
+Original,GeneralAbbreviation
+Microsoft,MS
+Windows,Win
+Operational,Op
+Diagnosis,Diag
+Package,Pkg
+Server,Svr
+Client,Cli
+Management,Mgmt
+Security,Sec
+Connection,Conn
+Application,App
+PowerShell,PwSh

--- a/config/provider_abbreviations.txt
+++ b/config/provider_abbreviations.txt
@@ -1,0 +1,12 @@
+Provider,Abbreviation
+Microsoft-Windows-Security-Auditing,Sec
+Microsoft-Windows-Sysmon,Sysmon
+Microsoft-Windows-TaskScheduler,TaskScheduler
+Microsoft-Windows-TerminalServices-LocalSessionManager,RDS-LSM
+Microsoft-Windows-TerminalServices-RemoteConnectionManager,RDS-RCM
+Microsoft-Windows-WMI-Activity,WMI-Activity
+Microsoft-Windows-WinRM,WinRM
+Microsoft-Windows-Windows Defender,Defender
+Microsoft-Windows-Windows Firewall With Advanced Security,Firewall
+Microsoft-Windows-WindowsUpdateClient,WinUpdate
+Service Control Manager,SCM


### PR DESCRIPTION
I added config file to abbreviate provider names.
I want to use `generic_abbreviations.txt` generically for both channel and provider names so would like to delete `channel_abbreviations_generic.txt` in the future. For now will leave it there until we change things in Hayabusa.