### PR TITLE
feat: convert deprecated rules

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,9 @@
 # 変更点
 
+## v2.3.0 [2023/03/24] 
+
+`deprecated`と`unsupported`のSigmaルールも、hayabusa-rulesリポジトリに追加されるようになった。
+
 ## v2.2.2 [2023/02/22] 
 
 `base64offset|contains`を使用するルールに対応した。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## v2.3.0 [2023/03/24] 
+
+`deprecated` and `unsupported` sigma rules are now also being added to the hayabusa-rules repository.
+
 ## v2.2.2 [2023/02/22] 
 
 Hayabusa now supports rules that use `base64offset|contains`.

--- a/tools/sigmac/convert.py
+++ b/tools/sigmac/convert.py
@@ -118,10 +118,11 @@ class Logconverter():
 
         logger.debug("target: " + file_name)
         if "logsource" in rule_data:
-            if "product" in rule_data["logsource"]:
-                    if rule_data["logsource"]["product"] != "windows":
-                        logger.info(file_name + " has no windows rule.")
-                        return convert_datas
+            if "product" not in rule_data["logsource"]:
+                return convert_datas
+            elif rule_data["logsource"]["product"] != "windows":
+                logger.info(file_name + " has no windows rule.")
+                return convert_datas
         if category in EXCLUDE_CATEGORY:
             logger.info(file_name + " has CATEGORY hayabusa couldn't use.")
             return convert_datas

--- a/tools/sigmac/convert.py
+++ b/tools/sigmac/convert.py
@@ -16,6 +16,8 @@ SIGMA_DIR = "./"
 SIGMAC_DIR = "./tools/"
 EXPORT_DIR_NAME = "./hayabusa_rules"
 RULES_DIR = "./rules/windows"
+RULES_UNSUPPORTED_DIR = "./rules-unsupported"
+RULES_DEPRECATED_DIR = "./rules-deprecated/windows"
 CPU = None
 IGNORE_CONFIGS = {"windows-services.yml", "powershell.yml"}
 EXCLUDE_CATEGORY = {"file_rename"}
@@ -31,7 +33,7 @@ def main():
         shutil.rmtree(EXPORT_DIR_NAME)
     os.mkdir(EXPORT_DIR_NAME)
     logconverter = Logconverter(SIGMA_DIR,
-        rules_dir=RULES_DIR,
+        rules_dirs=[RULES_DIR, RULES_UNSUPPORTED_DIR, RULES_DEPRECATED_DIR],
         config_dir=os.path.join(SIGMA_DIR, "tools/config/generic/")
     )
     logconverter.create_config_map()
@@ -52,11 +54,11 @@ class ConvertData(object):
 class Logconverter():
     rule_count = 0
 
-    def __init__(self, sigma_dir: str, rules_dir: str, config_dir: str):
+    def __init__(self, sigma_dir: str, rules_dirs: str, config_dir: str):
         self.config_map: dict[str, set[str]] = dict()
 
         self.sigma_dir = sigma_dir
-        self.rules_dir = rules_dir
+        self.rules_dirs = rules_dirs
         self.config_dir = config_dir
 
     def create_config_map(self):
@@ -76,7 +78,9 @@ class Logconverter():
                         self.config_map[category].add(config)
 
     def convert_rules(self):
-        convert_rule_list =self.create_rule_list(self.rules_dir)
+        convert_rule_list = list()
+        for rules_dir in self.rules_dirs:
+            convert_rule_list.extend(self.create_rule_list(rules_dir))
         print("Converting rules. Please wait.")
         with ThreadPool(CPU) as threadpool:
             result = threadpool.map(sigma_executer, convert_rule_list)
@@ -99,7 +103,11 @@ class Logconverter():
         category = None
 
         with open(rule_path, 'r') as yml:
-            rule_data = yaml.load(yml)
+            try:
+                rule_data = yaml.load(yml)
+            except:
+                logger.warning(rule_path + " failed to convert yml.")
+                return convert_datas
             if "logsource" in rule_data:
                 if "category" in rule_data["logsource"]:
                     category = rule_data["logsource"]["category"]
@@ -109,6 +117,11 @@ class Logconverter():
                 logger.warning(rule_path + " has no log category description.")
 
         logger.debug("target: " + file_name)
+        if "logsource" in rule_data:
+            if "product" in rule_data["logsource"]:
+                    if rule_data["logsource"]["product"] != "windows":
+                        logger.info(file_name + " has no windows rule.")
+                        return convert_datas
         if category in EXCLUDE_CATEGORY:
             logger.info(file_name + " has CATEGORY hayabusa couldn't use.")
             return convert_datas
@@ -117,7 +130,7 @@ class Logconverter():
         else:
             configs = set()
 
-        rule_path_from_rule_root = rule_path[len(self.rules_dir)+1:] # rm ./rules/windows
+        rule_path_from_rule_root = rule_path[len(self.rules_dirs)+1:] # rm ./rules/windows
         if rule_path_from_rule_root.startswith("builtin/"):
             rule_path_from_rule_root = rule_path_from_rule_root[8:] # rm .builtin
 

--- a/tools/sigmac/convert.py
+++ b/tools/sigmac/convert.py
@@ -130,7 +130,13 @@ class Logconverter():
         else:
             configs = set()
 
-        rule_path_from_rule_root = rule_path[len(self.rules_dirs)+1:] # rm ./rules/windows
+        rule_path_from_rule_root = rule_path
+        if RULES_DEPRECATED_DIR in rule_path:
+            rule_path_from_rule_root = rule_path.replace(RULES_DEPRECATED_DIR, "deprecated")
+        elif RULES_UNSUPPORTED_DIR in rule_path:
+            rule_path_from_rule_root = rule_path.replace(RULES_UNSUPPORTED_DIR, "unsupported")
+        else:
+            rule_path_from_rule_root = rule_path[len(RULES_DIR)+1:] # rm ./rules/windows
         if rule_path_from_rule_root.startswith("builtin/"):
             rule_path_from_rule_root = rule_path_from_rule_root[8:] # rm .builtin
 


### PR DESCRIPTION
## What Changed

- Fixed #327 
- The specifications of the folder hierarchy are as follows.
  - From: sigma/rules-deprecated 
    - To: sigma/builtin/deprecated
    - To: sigma/sysmon/deprecated
  - From: sigma/rules-unsupported/windows
    - To: sigma/builtin/unsupported
    - To: sigma/sysmon/unsupported

## Evidence
### Environment 
- OS: macOS montery version 13.1
- Hard: Macbook Air(M1, 2020) , Memory 8GB, Core 8
- Python 3.11

## Test1
I confirmed that there is no difference other than the deprecated/unsupported folder before/after fix.
```
fukusuke@fukusukenoAir sigma % diff -r hayabusa_rules_new hayabusa_rules_org
Only in hayabusa_rules_new/builtin: deprecated
Only in hayabusa_rules_new/builtin: unsupported
Only in hayabusa_rules_new/sysmon: deprecated
Only in hayabusa_rules_new/sysmon: unsupported
```

## Test2
I confirmed that unsupported/deprecated rules are targeted for detection.
(`Rule parsing errors: 5` are regex escape related, so I'll make PR to Sigma repository)
```
Loading detections rules. Please wait.

Excluded rules: 15
Noisy rules: 7 (Disabled)
Rule parsing errors: 5

Deprecated rules: 113 (3.14%) (Disabled)
Experimental rules: 1727 (48.00%)
Stable rules: 219 (6.09%)
Test rules: 1498 (41.63%)
Unsupported rules: 41 (1.14%)

Hayabusa rules: 149
Sigma rules: 3449
Total enabled detection rules: 3598

Scanning in progress. Please wait.
```

I would appreciate it if you could review🙏

Closes https://github.com/Yamato-Security/hayabusa-rules/issues/327