### PR TITLE
feat: keep `cidr` rule value as is

### DIFF
--- a/tools/sigmac/rule.py
+++ b/tools/sigmac/rule.py
@@ -81,13 +81,10 @@ class SigmaParser:
         elif type(definition) == dict:      # map
             cond = ConditionAND()
             for key, value in definition.items():
-                if "base64offset|contains" in key:
+                if "base64offset|contains" in key or "cidr" in key:
                     fieldname = key
                 elif "|" in key:  # field name contains value modifier
                     fieldname, *modifiers = key.split("|")
-                    if "cidr" in modifiers: # Add other unsupported modifiers here
-                        raise SigmaParseError("Cannot convert the rule. Unsupported new cidr modifier by SIGMAC. Please use the new PySigma/SigmaCLI to be able to convert the rule")
-                        break
                     value = apply_modifiers(value, modifiers)
                 else:
                     fieldname = key


### PR DESCRIPTION
## What Changed

Changed the conversion process to keep `cidr` value as is

## Evidence
### Environment 
- OS: macOS montery version 13.1
- Hard: Macbook Air(M1, 2020) , Memory 8GB, Core 8

### Test1
rule with the `|cidr` modifier conversion succeeded as follows
```
fukusuke@fukusukenoAir sigma % python3 ./tools/sigmac -t hayabusa -c ./tools/config/generic/windows-audit.yml -c ./tools/config/generic/windows-services.yml --defer-abort ./rules/windows/builtin/security/win_security_successful_external_remote_rdp_login.yml
title: External Remote RDP Logon from Public IP
ruletype: Sigma
author: Micah Babinski, @micahbabinski
date: 2023/01/19
description: Detects successful logon from public IP address via RDP. This can indicate
    a publicly-exposed RDP port.
detection:
    SELECTION_1:
        Channel: Security
    SELECTION_2:
        EventID: 4624
    SELECTION_3:
        LogonType: 10
    SELECTION_4:
        SubjectUserName: '-'
    SELECTION_5:
        IpAddress|cidr:
        - 10.0.0.0/8
        - 172.16.0.0/12
        - 192.168.0.0/16
        - 224.0.0.0/4
        - 127.0.0.0/8
    condition: (SELECTION_1 and (SELECTION_2 and SELECTION_3) and  not (SELECTION_4
        and SELECTION_5))
falsepositives:
- Legitimate or intentional inbound connections from public IP addresses on the RDP
    port.
id: 259a9cdf-c4dd-4fa2-b243-2269e5ab18a2
level: medium
logsource:
    product: windows
    service: security
references:
- https://www.inversecos.com/2020/04/successful-4624-anonymous-logons-to.html
- https://twitter.com/Purp1eW0lf/status/1616144561965002752
related:
-   id: 78d5cab4-557e-454f-9fb9-a222bd0d5edc
    type: derived
status: experimental
tags:
- attack.initial_access
- attack.credential_access
- attack.t1133
- attack.t1078
- attack.t1110
```

### Test2
Compared the results of `python3 convert.py` diff before/after fix.
I confirmed that rules related to `|cidr` are only the following (2 rules)
```
fukusuke@fukusukenoAir sigma % diff -r hayabusa_rules hayabusa_rules_new
Only in hayabusa_rules_20230315/builtin/security: win_security_successful_external_remote_rdp_login.yml
Only in hayabusa_rules_20230315/builtin/security: win_security_successful_external_remote_smb_login.yml
```

closes https://github.com/Yamato-Security/hayabusa-rules/issues/339