### PR TITLE
exclude regex parse error rules

### DIFF
--- a/config/exclude_rules.txt
+++ b/config/exclude_rules.txt
@@ -27,5 +27,12 @@ c0478ead-5336-46c2-bd5e-b4c84bc3a36e # Mimikatz In-Memory
 c069f460-2b87-4010-8dcf-e45bab362624 # APT29 Google Update Service Install
 7818b381-5eb1-4641-bea5-ef9e4cfb5951 # Possible Remote Password Change Through SAMR
 
+# Exclude unsupported rules that cause regex parsing errors
+82b66143-53ee-4369-ab02-de2c70cd6352 # Invoke-Obfuscation Via Stdin
+de7fb680-6efa-4bf3-af2c-14b6d33c8e6e # Invoke-Obfuscation STDIN+ Launcher
+7b9a650e-6788-4fdf-888d-ec7c0a62810d # Invoke-Obfuscation VAR++ LAUNCHER OBFUSCATION
+3e27b010-2cf2-4577-8ef0-3ea44aaea0dc # Invoke-Obfuscation VAR+ Launcher
+21e4b3c1-4985-4aa4-a6c0-f8639590a5f3 # Invoke-Obfuscation CLIP+ Launcher
+
 # Test Files
 00000000-0000-0000-0000-000000000000 # TestFile


### PR DESCRIPTION
could one of you check these?
maybe one day we can fix the regex in the rules but for now I want to ignore them.
Please merge if ok.