### PR TITLE
remove PIDs from pivot keywords

### DIFF
--- a/config/pivot_keywords.txt
+++ b/config/pivot_keywords.txt
@@ -13,7 +13,4 @@ Target IP Addresses.DestinationIp
 Target IP Addresses.DestAddress
 Processes.Image
 Processes.NewProcessName
-Process IDs.ProcessId
-Process IDs.NewProcessId
-Process GUIDs.ProcessGuid
 Command Lines.CommandLine


### PR DESCRIPTION
Process IDs and Process GUIDs create too long of a list with too many false positives so I deleted them.