### PR TITLE
chg: add support for `|all`(no-field) modifier rule

### DIFF
--- a/tools/sigmac/logsource_mapping.py
+++ b/tools/sigmac/logsource_mapping.py
@@ -105,10 +105,6 @@ class LogsourceConverter:
         """
         if isinstance(obj, dict):
             for field_name, val in list(obj.items()):
-                if field_name == "|all":
-                    # TODO Hayabusa側でフィールド名なしの'|all'に対応したらこの分岐は削除
-                    msg = f"Unsupported value-modifier '|all' found. Skip conversion."
-                    raise Exception(msg)
                 if not need_field_conversion:
                     return obj
                 self.transform_field(obj, field_name)


### PR DESCRIPTION
## What Changed
- Added support for `|all`(no-field) modifier rules
- Related PR:  https://github.com/Yamato-Security/hayabusa/pull/1060

## Evidence
### Environment 
- OS: macOS montery version 13.1
- Hard: MacBook Air(M1, 2020) , Memory 8GB, Core 8
- Python 3.11.1

### Test1
I confirmed that `logsource_mapping.py` completes successfully as follows.(`ERROR` is expected behavior)
```
[INFO:logsource_mapping.py:323] Start to logsource mapping sigma rules.
[INFO:logsource_mapping.py:355] Loading logsource mapping yaml(sysmon/windows-audit/windows-services) done.
[INFO:logsource_mapping.py:302] Start to collect target yml files path.
[ERROR:logsource_mapping.py:318] Error while loading yml [../../../sigma/unsupported/windows/win_apt_apt29_tor.yml]: expected a single document in the stream
  in "../../../sigma/unsupported/windows/win_apt_apt29_tor.yml", line 1, column 1
but found another document
  in "../../../sigma/unsupported/windows/win_apt_apt29_tor.yml", line 29, column 1
[ERROR:logsource_mapping.py:318] Error while loading yml [../../../sigma/unsupported/windows/sysmon_process_reimaging.yml]: expected a single document in the stream
  in "../../../sigma/unsupported/windows/sysmon_process_reimaging.yml", line 1, column 1
but found another document
  in "../../../sigma/unsupported/windows/sysmon_process_reimaging.yml", line 27, column 1
[ERROR:logsource_mapping.py:318] Error while loading yml [../../../sigma/unsupported/windows/win_remote_service.yml]: expected a single document in the stream
  in "../../../sigma/unsupported/windows/win_remote_service.yml", line 1, column 1
but found another document
  in "../../../sigma/unsupported/windows/win_remote_service.yml", line 37, column 1
[INFO:logsource_mapping.py:359] Collecting target yml files path done. Start to convert [2408] files.
[ERROR:logsource_mapping.py:174] Invalid character in condition [process_creation and (write ProcessGuid from (event_id and image_2 and not system_user) to %suspicious_guid%; then if (child_of_suspicious_guid and event_id and image_1 and system_user) or (suspicious_guid and event_id and image_2 and system_user and integrity_level) -> alert)] file [../../../sigma/unsupported/windows/sysmon_always_install_elevated_parent_child_correlated.yml]. Skip conversion.
[ERROR:logsource_mapping.py:174] Invalid character in condition [process_creation and (write ProcessGuid from (event_id and image_2 and not system_user) to %suspicious_guid%; then if (child_of_suspicious_guid and event_id and image_1 and system_user) or (suspicious_guid and event_id and image_2 and system_user and integrity_level) -> alert)] file [../../../sigma/unsupported/windows/sysmon_always_install_elevated_parent_child_correlated.yml]. Skip conversion.
[ERROR:logsource_mapping.py:174] Invalid character in condition [security and (write TargetLogonId from selection1 (if not selection2) to list %SuspiciousTargetLogonIdList%; then if selection3 -> alert)] file [../../../sigma/unsupported/windows/win_dumping_ntdsdit_via_dcsync.yml]. Skip conversion.
[ERROR:logsource_mapping.py:174] Invalid character in condition [security and (write TargetLogonId from selection1 (if not selection2) to list %SuspiciousTargetLogonIdList%; then if selection3 -> alert)] file [../../../sigma/unsupported/windows/win_dumping_ntdsdit_via_netsync.yml]. Skip conversion.
[ERROR:logsource_mapping.py:374] Error while converting rule [../../../sigma/rules/windows/file/file_rename/file_rename_win_ransomware.yml]: This rule has inconvertible service:[file_rename]. Skip conversion.
[ERROR:logsource_mapping.py:374] Error while converting rule [../../../sigma/rules/windows/file/file_rename/file_rename_win_not_dll_to_dll.yml]: This rule has inconvertible service:[file_rename]. Skip conversion.
[ERROR:logsource_mapping.py:374] Error while converting rule [../../../sigma/rules/windows/file/file_access/file_access_win_susp_cred_hist_access.yml]: This rule has inconvertible service:[file_access]. Skip conversion.
[ERROR:logsource_mapping.py:374] Error while converting rule [../../../sigma/rules/windows/file/file_access/file_access_win_dpapi_master_key_access.yml]: This rule has inconvertible service:[file_access]. Skip conversion.
[ERROR:logsource_mapping.py:374] Error while converting rule [../../../sigma/rules/windows/file/file_access/file_access_win_browser_credential_stealing.yml]: This rule has inconvertible service:[file_access]. Skip conversion.
[ERROR:logsource_mapping.py:374] Error while converting rule [../../../sigma/rules/windows/file/file_access/file_access_win_credential_manager_stealing.yml]: This rule has inconvertible service:[file_access]. Skip conversion.
[INFO:logsource_mapping.py:376] [3795] files created successfully. Created files were saved under [./converted_sigma_rules].
[INFO:logsource_mapping.py:377] Script took [9.81] seconds.

```

### Test2

The following 6 rules including `|all` in the version before This PR,
```
[ERROR:logsource_mapping.py:378] Error while converting rule [../../../sigma/rules/windows/builtin/system/microsoft_windows_kernel_general/win_system_susp_sam_dump.yml]: Unsupported value-modifier '|all' found. Skip conversion.
[ERROR:logsource_mapping.py:378] Error while converting rule [../../../sigma/rules/windows/builtin/msexchange/win_exchange_proxyshell_certificate_generation.yml]: Unsupported value-modifier '|all' found. Skip conversion.
[ERROR:logsource_mapping.py:378] Error while converting rule [../../../sigma/rules/windows/builtin/msexchange/win_exchange_set_oabvirtualdirectory_externalurl.yml]: Unsupported value-modifier '|all' found. Skip conversion.
[ERROR:logsource_mapping.py:378] Error while converting rule [../../../sigma/rules/windows/builtin/msexchange/win_exchange_proxyshell_remove_mailbox_export.yml]: Unsupported value-modifier '|all' found. Skip conversion.
[ERROR:logsource_mapping.py:378] Error while converting rule [../../../sigma/rules/windows/builtin/msexchange/win_exchange_proxylogon_oabvirtualdir.yml]: Unsupported value-modifier '|all' found. Skip conversion.
[ERROR:logsource_mapping.py:378] Error while converting rule [../../../sigma/rules/windows/builtin/msexchange/win_exchange_proxyshell_mailbox_export.yml]: Unsupported value-modifier '|all' found. Skip conversion.
```
converted successfully as follows. Also, there is no difference in other files.
```
fukusuke@fukusukenoMacBook-Air sigmac % diff -r ./converted_sigma_rules_new ./converted_sigma_rules_old
Only in ./converted_sigma_rules_new/builtin/deprecated: powershell_suspicious_invocation_specific.yml
Only in ./converted_sigma_rules_new/builtin/msexchange: win_exchange_proxylogon_oabvirtualdir.yml
Only in ./converted_sigma_rules_new/builtin/msexchange: win_exchange_proxyshell_certificate_generation.yml
Only in ./converted_sigma_rules_new/builtin/msexchange: win_exchange_proxyshell_mailbox_export.yml
Only in ./converted_sigma_rules_new/builtin/msexchange: win_exchange_proxyshell_remove_mailbox_export.yml
Only in ./converted_sigma_rules_new/builtin/msexchange: win_exchange_set_oabvirtualdirectory_externalurl.yml
Only in ./converted_sigma_rules_new/builtin/system/microsoft_windows_kernel_general: win_system_susp_sam_dump.yml
```

### Test3
For example converted `win_system_susp_sam_dump.yml` is as follows.(`|all` remains)
```
title: SAM Dump to AppData
id: 839dd1e8-eda8-4834-8145-01beeee33acd
status: test
description: Detects suspicious SAM dump activity as cause by QuarksPwDump and other
    password dumpers
author: Florian Roth (Nextron Systems)
date: 2018/01/27
modified: 2023/04/30
tags:
    - attack.credential_access
    - attack.t1003.002
logsource:
    product: windows
    service: system
    definition: The source of this type of event is Kernel-General
detection:
    system:
        Channel: System
    selection:
        Provider_Name: Microsoft-Windows-Kernel-General
        EventID: 16
    keywords:
        '|all':
            - \AppData\Local\Temp\SAM-
            - .dmp
    condition: system and (selection and keywords)
falsepositives:
    - Unknown
level: high
ruletype: Sigma
```

### Test4
I confirmed that there are no rule conversion errors as follows.
```
fukusuke@fukusukenoMacBook-Air hayabusa-2.5.1-all-platforms % ./hayabusa csv-timeline -r ~/Scripts/hayabusa-rules/tools/sigmac/converted_sigma_rules_new -d ../hayabusa-sample-evtx -o 2.csv -q
Start time: 2023/06/10 06:48

Total event log files: 584
Total file size: 138.2 MB

Loading detections rules. Please wait.

Excluded rules: 30

Deprecated rules: 169 (4.76%) (Disabled)
Experimental rules: 1979 (55.70%)
Stable rules: 103 (2.90%)
Test rules: 1471 (41.40%)
Unsupported rules: 43 (1.21%) (Disabled)

Sigma rules: 3553
Total enabled detection rules: 3553

Output profile: standard

Scanning in progress. Please wait.
```

I would appreciate it if you could review🙏