### PR TITLE
add |contains|all explanation

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -476,6 +476,15 @@ detection:
 - `|startswith`: 指定された文字列で始まることをチェックします。
 - `|endswith`: 指定された文字列で終わることをチェックします。
 - `|contains`: 指定された文字列が含まれることをチェックします。
+- `|contains|all`: 指定された複数の文字列が含まれることをチェックします。
+
+この例では、`ForEach``Xor`という文字列の両方が`CommandLine`フィールドに存在する必要があります:
+```
+CommandLine|contains|all:
+    - ForEach
+    - Xor
+```
+
 - `|re`: 正規表現を使用します。(正規表現の書き方については <https://docs.rs/regex/latest/regex/#syntax> を参照してください)。
   > 注意: SigmaルールとHayabusaルールは正規表現の記法に一部差異があります。そのため、HayabusaではSigmaルールを正しく検知できない場合があります。
 - `|equalsfield`: 指定されたイベントキーと合致することをチェックします。2つのフィールドの値が一致しないことをチェックしたい場合は`condition`で`not`を使ってください。

--- a/README.md
+++ b/README.md
@@ -475,6 +475,15 @@ String matches are case insensitive. However, they become case sensitive wheneve
 - `|startswith`: Checks the string from the beginning
 - `|endswith`: Checks the end of the string
 - `|contains`: Checks if a word is contained in the data
+- `|contains|all`: Checks if multiple words are contained in the data
+
+In this example, both `ForEach` and `Xor` strings need to be present in the `CommandLine` field:
+```
+CommandLine|contains|all:
+    - ForEach
+    - Xor
+```
+
 - `|re`: Use regular expressions. (We are using the regex crate so please out the documentation at <https://docs.rs/regex/latest/regex/#syntax> to learn how to write correct regular expressions.)
 > Caution: Regular expression syntax in sigma rules is still not defined so some sigma rules may not match correctly if they differ from the Rust regex syntax.
 - `|equalsfield`: Check if two fields have the same value. You can use `not` in the `condition` if you want to check if two fields are different.


### PR DESCRIPTION
There was no explanation for `|contains|all` so I added it.