### PR TITLE
refactor: remove duplicated keys in yml

### DIFF
--- a/hayabusa/builtin/WindowsDefender/Defender_1116_Crit_Alert.yml
+++ b/hayabusa/builtin/WindowsDefender/Defender_1116_Crit_Alert.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis, Fukusuke Takahashi
 date: 2021/12/01
-modified: 2023/3/27
+modified: 2023/6/17
 
 title: 'Defender Alert (Severe)'
 description: Windows defender malware detection
@@ -22,5 +22,4 @@ tags:
     - malware
 references:
     - https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus?view=o365-worldwide
-logsource: default
 ruletype: Hayabusa

--- a/hayabusa/builtin/WindowsDefender/Defender_1116_High_Alert.yml
+++ b/hayabusa/builtin/WindowsDefender/Defender_1116_High_Alert.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis, Fukusuke Takahashi
 date: 2021/12/01
-modified: 2023/3/27
+modified: 2023/6/17
 
 title: 'Defender Alert (High)'
 description: Windows defender malware detection
@@ -22,5 +22,4 @@ tags:
     - malware
 references:
     - https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus?view=o365-worldwide
-logsource: default
 ruletype: Hayabusa

--- a/hayabusa/builtin/WindowsDefender/Defender_1116_Low_Alert.yml
+++ b/hayabusa/builtin/WindowsDefender/Defender_1116_Low_Alert.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis, Fukusuke Takahashi
 date: 2021/12/01
-modified: 2023/3/27
+modified: 2023/6/17
 
 title: 'Defender Alert (Low)'
 description: 'Windows defender malware detection'
@@ -22,5 +22,4 @@ tags:
     - malware
 references:
     - https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus?view=o365-worldwide
-logsource: default
 ruletype: Hayabusa

--- a/hayabusa/builtin/WindowsDefender/Defender_1116_Med_Alert.yml
+++ b/hayabusa/builtin/WindowsDefender/Defender_1116_Med_Alert.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis, Fukusuke Takahashi
 date: 2021/12/01
-modified: 2023/3/27
+modified: 2023/6/17
 
 title: 'Defender Alert (Moderate)'
 description: 'Windows defender malware detection'
@@ -22,5 +22,4 @@ tags:
     - malware
 references:
     - https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus?view=o365-worldwide
-logsource: default
 ruletype: Hayabusa

--- a/hayabusa/sysmon/Sysmon_22_Med_DNS-Query_RuleAlert.yml
+++ b/hayabusa/sysmon/Sysmon_22_Med_DNS-Query_RuleAlert.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/23
-modified: 2023/01/13
+modified: 2023/06/17
 
 title: 'DNS Query (Sysmon Alert)'
 details: 'Rule: %RuleName ¦ Query: %QueryName% ¦ Result: %QueryResults% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%' 
@@ -8,7 +8,6 @@ details: 'Rule: %RuleName ¦ Query: %QueryName% ¦ Result: %QueryResults% ¦ Pro
 description: |
     This event is generated when a process executes a DNS query, whether the result is successful or fails, cached or not. 
     The telemetry for this event was added for Windows 8.1 so it is not available on Windows 7 and earlier.
-details: 'Rule: %RuleName% ¦ Query: %QueryName% ¦ Result: %QueryResults% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%'
 
 id: 6a633cec-1e7b-4c34-903e-d5afceba585b
 level: medium


### PR DESCRIPTION
## What Changed
Some rules had duplicate keys as follows, so I deleted them.
(For example, the `logsource` is duplicated in the example below.)
```
id: 810bfd3a-9fb3-44e0-9016-8cdf785fddbf
level: critical
status: test
logsource:
    product: windows
    service: windefend
detection:
    selection:
        Channel: Microsoft-Windows-Windows Defender/Operational
        EventID: 1116
        SeverityID: 5 # Severe
falsepositives:
    - bad signature
tags:
    - malware
references:
    - https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus?view=o365-worldwide
logsource: default
ruletype: Hayabusa
```
I would appreciate it if you could review🙏