### PR TITLE
feat: add `sysmon` tag when logsource service is `sysmon`

### DIFF
--- a/tools/sigmac/logsource_mapping.py
+++ b/tools/sigmac/logsource_mapping.py
@@ -250,8 +250,9 @@ class LogsourceConverter:
         for ls in logsources:
             new_obj = copy.deepcopy(obj)
             if ls.service == "sysmon":
-                if "tags" in new_obj and "sysmon" not in new_obj["tags"]:
-                    new_obj["tags"].append("sysmon")
+                if "tags" in new_obj:
+                    if "sysmon" not in new_obj["tags"]:
+                        new_obj["tags"].append("sysmon")
                 else:
                     new_obj["tags"] = ["sysmon"]
             detection = copy.deepcopy(new_obj['detection'])

--- a/tools/sigmac/logsource_mapping.py
+++ b/tools/sigmac/logsource_mapping.py
@@ -249,6 +249,11 @@ class LogsourceConverter:
             return  # ログソースマッピングにないcategory/serviceのため、変換処理はスキップ
         for ls in logsources:
             new_obj = copy.deepcopy(obj)
+            if ls.service == "sysmon":
+                if "tags" in new_obj and "sysmon" not in new_obj["tags"]:
+                    new_obj["tags"].append("sysmon")
+                else:
+                    new_obj["tags"] = ["sysmon"]
             detection = copy.deepcopy(new_obj['detection'])
             # 出力時に順番を logsource -> selection -> conditionにしたいので一旦クリア
             new_obj['detection'] = dict()


### PR DESCRIPTION
## What Changed

- Fixed #453 
- Added process for adding `sysmon` tag when logsource is `sysmon`

## Evidence
### Test Environment 
- OS: macOS montery version 13.1
- Hard: MacBook Air(M1, 2020) , Memory 8GB, Core 8
- Python 3.11.1

## Test1
I confirmed that `logsource` == `sysmon` are tagged.
[proc_creation_win_conhost_uncommon_parent.yml](https://github.com/SigmaHQ/sigma/blob/c0332a9d96f6c7804fcc85dd706caed889446a62/rules/windows/process_creation/proc_creation_win_conhost_uncommon_parent.yml#L2)

`logsource_mapping.py`'s output rule is as follows.
```
title: Conhost Spawned By Uncommon Parent Process
id: cbb9e3d1-2386-4e59-912e-62f1484f7a89
status: experimental
description: Detects when the Console Window Host (conhost.exe) process is spawned
    by an uncommon parent process, which could be indicative of potential code injection
    activity.
references:
    - https://www.elastic.co/guide/en/security/current/conhost-spawned-by-suspicious-parent-process.html
author: Tim Rauch
date: 2022/09/28
modified: 2023/03/29
tags:
    - attack.execution
    - attack.t1059
    - sysmon
logsource:
    category: process_creation
    product: windows
detection:
    process_creation:
        EventID: 1
        Channel: Microsoft-Windows-Sysmon/Operational
    selection:
        Image|endswith: \conhost.exe
        ParentImage|endswith:
            - \explorer.exe
            - \lsass.exe
            - \regsvr32.exe
            - \rundll32.exe
            - \services.exe
            - \smss.exe
            - \spoolsv.exe
            - \svchost.exe
            - \userinit.exe
            - \wininit.exe
            - \winlogon.exe
    filter_main_svchost:
        ParentCommandLine|contains:
            - -k apphost -s AppHostSvc
            - -k imgsvc
            - -k localService -p -s RemoteRegistry
            - -k LocalSystemNetworkRestricted -p -s NgcSvc
            - -k NetSvcs -p -s NcaSvc
            - -k netsvcs -p -s NetSetupSvc
            - -k netsvcs -p -s wlidsvc
            - -k NetworkService -p -s DoSvc
            - -k wsappx -p -s AppXSvc
            - -k wsappx -p -s ClipSVC
    filter_optional_dropbox:
        ParentCommandLine|contains:
            - C:\Program Files (x86)\Dropbox\Client\
            - C:\Program Files\Dropbox\Client\
    condition: process_creation and (selection and not 1 of filter_main_* and not
        1 of filter_optional_*)
falsepositives:
    - Unknown
level: medium
ruletype: Sigma
```

## Test2
I confirmed that `logsource` other than `sysmon` are not tagged.
[win_application_msmpeng_crash_error.yml](https://github.com/SigmaHQ/sigma/blob/c0332a9d96f6c7804fcc85dd706caed889446a62/rules/windows/builtin/application/application_error/win_application_msmpeng_crash_error.yml#L4)
`logsource_mapping.py`'s output rule is as follows.
```
title: Microsoft Malware Protection Engine Crash
id: 545a5da6-f103-4919-a519-e9aec1026ee4
related:
    -   id: 6c82cf5c-090d-4d57-9188-533577631108
        type: similar
status: experimental
description: This rule detects a suspicious crash of the Microsoft Malware Protection
    Engine
references:
    - https://bugs.chromium.org/p/project-zero/issues/detail?id=1252&desc=5
    - https://technet.microsoft.com/en-us/library/security/4022344
author: Florian Roth (Nextron Systems)
date: 2017/05/09
modified: 2023/04/14
tags:
    - attack.defense_evasion
    - attack.t1211
    - attack.t1562.001
logsource:
    product: windows
    service: application
detection:
    application:
        Channel: Application
    selection:
        Provider_Name: Application Error
        EventID: 1000
        Data|contains|all:
            - MsMpEng.exe
            - mpengine.dll
    condition: application and selection
falsepositives:
    - MsMpEng might crash if the "C:\" partition is full
level: high
ruletype: Sigma
```

I would appreciate it if you could review🙏