### PR TITLE
feat: add `antivirus` category conversion

### DIFF
--- a/sigma/builtin/category/antivirus/av_exploiting.yml
+++ b/sigma/builtin/category/antivirus/av_exploiting.yml
@@ -1,0 +1,70 @@
+title: Antivirus Exploitation Framework Detection
+id: 238527ad-3c2c-4e4f-a1f6-92fd63adb864
+status: stable
+description: Detects a highly relevant Antivirus alert that reports an exploitation
+    framework
+references:
+    - https://www.nextron-systems.com/?s=antivirus
+    - https://www.virustotal.com/gui/file/925b0b28472d4d79b4bf92050e38cc2b8f722691c713fc28743ac38551bc3797
+    - https://www.virustotal.com/gui/file/8f8daabe1c8ceb5710949283818e16c4aa8059bf2ce345e2f2c90b8692978424
+    - https://www.virustotal.com/gui/file/d9669f7e3eb3a9cdf6a750eeb2ba303b5ae148a43e36546896f1d1801e912466
+author: Florian Roth (Nextron Systems), Arnim Rupp
+date: 2018/09/09
+modified: 2023/01/13
+tags:
+    - attack.execution
+    - attack.t1203
+    - attack.command_and_control
+    - attack.t1219
+logsource:
+    category: antivirus
+    product: windows
+    service: windefend
+detection:
+    antivirus:
+        EventID:
+            - 1006
+            - 1007
+            - 1008
+            - 1009
+            - 1010
+            - 1011
+            - 1012
+            - 1115
+            - 1116
+            - 1017
+            - 1018
+            - 1019
+            - 1115
+            - 1116
+        Channel: Microsoft-Windows-Windows Defender/Operational
+    selection:
+        ThreatName|contains:
+            - MeteTool
+            - MPreter
+            - Meterpreter
+            - Metasploit
+            - PowerSploit
+            - CobaltStrike
+            - BruteR
+            - Brutel
+            - Swrort
+            - Rozena
+            - Backdoor.Cobalt
+            - CobaltStr
+            - COBEACON
+            - Cometer
+            - Razy
+            - IISExchgSpawnCMD
+            - Exploit.Script.CVE
+            - Seatbelt
+            - Sbelt
+            - Sliver
+    condition: antivirus and selection
+fields:
+    - FileName
+    - User
+falsepositives:
+    - Unlikely
+level: critical
+ruletype: Sigma

--- a/sigma/builtin/category/antivirus/av_hacktool.yml
+++ b/sigma/builtin/category/antivirus/av_hacktool.yml
@@ -1,0 +1,89 @@
+title: Antivirus Hacktool Detection
+id: fa0c05b6-8ad3-468d-8231-c1cbccb64fba
+status: stable
+description: Detects a highly relevant Antivirus alert that reports a hack tool or
+    other attack tool
+references:
+    - https://www.nextron-systems.com/2021/08/16/antivirus-event-analysis-cheat-sheet-v1-8-2/
+    - https://www.nextron-systems.com/?s=antivirus
+author: Florian Roth (Nextron Systems), Arnim Rupp
+date: 2021/08/16
+modified: 2023/02/03
+tags:
+    - attack.execution
+    - attack.t1204
+logsource:
+    category: antivirus
+    product: windows
+    service: windefend
+detection:
+    antivirus:
+        EventID:
+            - 1006
+            - 1007
+            - 1008
+            - 1009
+            - 1010
+            - 1011
+            - 1012
+            - 1115
+            - 1116
+            - 1017
+            - 1018
+            - 1019
+            - 1115
+            - 1116
+        Channel: Microsoft-Windows-Windows Defender/Operational
+    selection:
+        -   ThreatName|startswith:
+                - HTOOL
+                - HKTL
+                - SecurityTool
+                - Adfind
+                - ATK/
+                - Exploit.Script.CVE
+                - PWS.
+                - PWSX
+        -   ThreatName|contains:
+                - Hacktool
+                - ATK/
+                - Potato
+                - Rozena
+                - Sbelt
+                - Seatbelt
+                - SecurityTool
+                - SharpDump
+                - Sliver
+                - Splinter
+                - Swrort
+                - Impacket
+                - Koadic
+                - Lazagne
+                - Metasploit
+                - Meterpreter
+                - MeteTool
+                - Mimikatz
+                - Mpreter
+                - Nighthawk
+                - PentestPowerShell
+                - PowerSploit
+                - PowerSSH
+                - PshlSpy
+                - PSWTool
+                - PWCrack
+                - Brutel
+                - BruteR
+                - Cobalt
+                - COBEACON
+                - Cometer
+                - DumpCreds
+                - FastReverseProxy
+                - PWDump
+    condition: antivirus and selection
+fields:
+    - FileName
+    - User
+falsepositives:
+    - Unlikely
+level: high
+ruletype: Sigma

--- a/sigma/builtin/category/antivirus/av_password_dumper.yml
+++ b/sigma/builtin/category/antivirus/av_password_dumper.yml
@@ -1,0 +1,66 @@
+title: Antivirus Password Dumper Detection
+id: 78cc2dd2-7d20-4d32-93ff-057084c38b93
+status: stable
+description: Detects a highly relevant Antivirus alert that reports a password dumper
+references:
+    - https://www.nextron-systems.com/?s=antivirus
+    - https://www.virustotal.com/gui/file/5fcda49ee7f202559a6cbbb34edb65c33c9a1e0bde9fa2af06a6f11b55ded619
+    - https://www.virustotal.com/gui/file/a4edfbd42595d5bddb442c82a02cf0aaa10893c1bf79ea08b9ce576f82749448
+author: Florian Roth (Nextron Systems)
+date: 2018/09/09
+modified: 2023/01/18
+tags:
+    - attack.credential_access
+    - attack.t1003
+    - attack.t1558
+    - attack.t1003.001
+    - attack.t1003.002
+logsource:
+    category: antivirus
+    product: windows
+    service: windefend
+detection:
+    antivirus:
+        EventID:
+            - 1006
+            - 1007
+            - 1008
+            - 1009
+            - 1010
+            - 1011
+            - 1012
+            - 1115
+            - 1116
+            - 1017
+            - 1018
+            - 1019
+            - 1115
+            - 1116
+        Channel: Microsoft-Windows-Windows Defender/Operational
+    selection:
+        -   ThreatName|startswith: PWS
+        -   ThreatName|contains:
+                - DumpCreds
+                - Mimikatz
+                - PWCrack
+                - HTool/WCE
+                - PSWTool
+                - PWDump
+                - SecurityTool
+                - PShlSpy
+                - Rubeus
+                - Kekeo
+                - LsassDump
+                - Outflank
+                - DumpLsass
+                - SharpDump
+                - PWSX
+                - PWS.
+    condition: antivirus and selection
+fields:
+    - FileName
+    - User
+falsepositives:
+    - Unlikely
+level: critical
+ruletype: Sigma

--- a/sigma/builtin/category/antivirus/av_printernightmare_cve_2021_34527.yml
+++ b/sigma/builtin/category/antivirus/av_printernightmare_cve_2021_34527.yml
@@ -1,0 +1,51 @@
+title: Antivirus PrinterNightmare CVE-2021-34527 Exploit Detection
+id: 6fe1719e-ecdf-4caf-bffe-4f501cb0a561
+status: stable
+description: Detects the suspicious file that is created from PoC code against Windows
+    Print Spooler Remote Code Execution Vulnerability CVE-2021-34527 (PrinterNightmare),
+    CVE-2021-1675 .
+references:
+    - https://twitter.com/mvelazco/status/1410291741241102338
+    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1675
+    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
+author: Sittikorn S, Nuttakorn T, Tim Shelton
+date: 2021/07/01
+modified: 2022/03/22
+tags:
+    - attack.privilege_escalation
+    - attack.t1055
+logsource:
+    category: antivirus
+    product: windows
+    service: windefend
+detection:
+    antivirus:
+        EventID:
+            - 1006
+            - 1007
+            - 1008
+            - 1009
+            - 1010
+            - 1011
+            - 1012
+            - 1115
+            - 1116
+            - 1017
+            - 1018
+            - 1019
+            - 1115
+            - 1116
+        Channel: Microsoft-Windows-Windows Defender/Operational
+    selection:
+        Path|contains: C:\Windows\System32\spool\drivers\x64\
+    keywords:
+        - File submitted to Symantec
+    condition: antivirus and (selection and not keywords)
+fields:
+    - ThreatName
+    - Path
+    - ComputerName
+falsepositives:
+    - Unlikely, or pending PSP analysis
+level: critical
+ruletype: Sigma

--- a/sigma/builtin/category/antivirus/av_ransomware.yml
+++ b/sigma/builtin/category/antivirus/av_ransomware.yml
@@ -1,0 +1,61 @@
+title: Antivirus Ransomware Detection
+id: 4c6ca276-d4d0-4a8c-9e4c-d69832f8671f
+status: test
+description: Detects a highly relevant Antivirus alert that reports ransomware
+references:
+    - https://www.nextron-systems.com/?s=antivirus
+    - https://www.virustotal.com/gui/file/43b0f7872900bd234975a0877744554f4f355dc57505517abd1ef611e1ce6916
+    - https://www.virustotal.com/gui/file/c312c05ddbd227cbb08958876df2b69d0f7c1b09e5689eb9d93c5b357f63eff7
+    - https://www.virustotal.com/gui/file/20179093c59bca3acc6ce9a4281e8462f577ffd29fd7bf51cf2a70d106062045
+    - https://www.virustotal.com/gui/file/554db97ea82f17eba516e6a6fdb9dc04b1d25580a1eb8cb755eeb260ad0bd61d
+    - https://www.virustotal.com/gui/file/69fe77dd558e281621418980040e2af89a2547d377d0f2875502005ce22bc95c
+author: Florian Roth (Nextron Systems), Arnim Rupp
+date: 2022/05/12
+modified: 2023/02/03
+tags:
+    - attack.t1486
+logsource:
+    category: antivirus
+    product: windows
+    service: windefend
+detection:
+    antivirus:
+        EventID:
+            - 1006
+            - 1007
+            - 1008
+            - 1009
+            - 1010
+            - 1011
+            - 1012
+            - 1115
+            - 1116
+            - 1017
+            - 1018
+            - 1019
+            - 1115
+            - 1116
+        Channel: Microsoft-Windows-Windows Defender/Operational
+    selection:
+        ThreatName|contains:
+            - Ransom
+            - Cryptor
+            - Crypter
+            - CRYPTES
+            - GandCrab
+            - BlackWorm
+            - Phobos
+            - Destructor
+            - Filecoder
+            - GrandCrab
+            - Krypt
+            - Locker
+            - Ryuk
+            - Ryzerlo
+            - Tescrypt
+            - TeslaCrypt
+    condition: antivirus and selection
+falsepositives:
+    - Unlikely
+level: critical
+ruletype: Sigma

--- a/sigma/builtin/category/antivirus/av_relevant_files.yml
+++ b/sigma/builtin/category/antivirus/av_relevant_files.yml
@@ -1,0 +1,98 @@
+title: Antivirus Relevant File Paths Alerts
+id: c9a88268-0047-4824-ba6e-4d81ce0b907c
+status: test
+description: Detects an Antivirus alert in a highly relevant file path or with a relevant
+    file name
+references:
+    - https://www.nextron-systems.com/?s=antivirus
+author: Florian Roth (Nextron Systems), Arnim Rupp
+date: 2018/09/09
+modified: 2023/05/19
+tags:
+    - attack.resource_development
+    - attack.t1588
+logsource:
+    category: antivirus
+    product: windows
+    service: windefend
+detection:
+    antivirus:
+        EventID:
+            - 1006
+            - 1007
+            - 1008
+            - 1009
+            - 1010
+            - 1011
+            - 1012
+            - 1115
+            - 1116
+            - 1017
+            - 1018
+            - 1019
+            - 1115
+            - 1116
+        Channel: Microsoft-Windows-Windows Defender/Operational
+    selection_path:
+        Path|contains:
+            - C:\Windows\
+            - C:\Temp\
+            - C:\PerfLogs\
+            - C:\Users\Public\
+            - C:\Users\Default\
+            - \Client\
+            - \tsclient\
+            - \inetpub\
+            - /www/
+            - apache
+            - tomcat
+            - nginx
+            - weblogic
+    selection_ext:
+        Path|endswith:
+            - .asax
+            - .ashx
+            - .asmx
+            - .asp
+            - .aspx
+            - .bat
+            - .cfm
+            - .cgi
+            - .chm
+            - .cmd
+            - .dat
+            - .ear
+            - .gif
+            - .hta
+            - .jpeg
+            - .jpg
+            - .jsp
+            - .jspx
+            - .lnk
+            - .php
+            - .pl
+            - .png
+            - .ps1
+            - .psm1
+            - .py
+            - .pyc
+            - .rb
+            - .scf
+            - .sct
+            - .sh
+            - .svg
+            - .txt
+            - .vbe
+            - .vbs
+            - .war
+            - .wsf
+            - .wsh
+            - .xml
+    condition: antivirus and (1 of selection_*)
+fields:
+    - ThreatName
+    - User
+falsepositives:
+    - Unlikely
+level: high
+ruletype: Sigma

--- a/sigma/builtin/category/antivirus/av_webshell.yml
+++ b/sigma/builtin/category/antivirus/av_webshell.yml
@@ -1,0 +1,109 @@
+title: Antivirus Web Shell Detection
+id: fdf135a2-9241-4f96-a114-bb404948f736
+status: test
+description: Detects a highly relevant Antivirus alert that reports a web shell. It's
+    highly recommended to tune this rule to the specific strings used by your anti
+    virus solution by downloading a big webshell repo from e.g. github and checking
+    the matches.
+references:
+    - https://www.nextron-systems.com/?s=antivirus
+    - https://github.com/tennc/webshell
+    - https://www.virustotal.com/gui/file/bd1d52289203866645e556e2766a21d2275877fbafa056a76fe0cf884b7f8819/detection
+    - https://www.virustotal.com/gui/file/308487ed28a3d9abc1fec7ebc812d4b5c07ab025037535421f64c60d3887a3e8/detection
+    - https://www.virustotal.com/gui/file/7d3cb8a8ff28f82b07f382789247329ad2d7782a72dde9867941f13266310c80/detection
+    - https://www.virustotal.com/gui/file/e841675a4b82250c75273ebf0861245f80c6a1c3d5803c2d995d9d3b18d5c4b5/detection
+    - https://www.virustotal.com/gui/file/a80042c61a0372eaa0c2c1e831adf0d13ef09feaf71d1d20b216156269045801/detection
+    - https://www.virustotal.com/gui/file/b219f7d3c26f8bad7e175934cd5eda4ddb5e3983503e94ff07d39c0666821b7e/detection
+    - https://www.virustotal.com/gui/file/b8702acf32fd651af9f809ed42d15135f842788cd98d81a8e1b154ee2a2b76a2/detection
+    - https://www.virustotal.com/gui/file/13ae8bfbc02254b389ab052aba5e1ba169b16a399d9bc4cb7414c4a73cd7dc78/detection
+author: Florian Roth (Nextron Systems), Arnim Rupp
+date: 2018/09/09
+modified: 2023/02/03
+tags:
+    - attack.persistence
+    - attack.t1505.003
+logsource:
+    category: antivirus
+    product: windows
+    service: windefend
+detection:
+    antivirus:
+        EventID:
+            - 1006
+            - 1007
+            - 1008
+            - 1009
+            - 1010
+            - 1011
+            - 1012
+            - 1115
+            - 1116
+            - 1017
+            - 1018
+            - 1019
+            - 1115
+            - 1116
+        Channel: Microsoft-Windows-Windows Defender/Operational
+    selection:
+        -   ThreatName|startswith:
+                - PHP.
+                - JSP.
+                - ASP.
+                - Perl.
+                - VBS/Uxor
+                - IIS/BackDoor
+                - JAVA/Backdoor
+                - Troj/ASP
+                - Troj/PHP
+                - Troj/JSP
+        -   ThreatName|contains:
+                - Webshell
+                - Chopper
+                - SinoChoper
+                - ASPXSpy
+                - Aspdoor
+                - filebrowser
+                - PHP_
+                - JSP_
+                - ASP_
+                - 'PHP:'
+                - 'JSP:'
+                - 'ASP:'
+                - 'Perl:'
+                - PHP/
+                - JSP/
+                - ASP/
+                - Perl/
+                - PHPShell
+                - Trojan.PHP
+                - Trojan.ASP
+                - Trojan.JSP
+                - Trojan.VBS
+                - PHP/Agent
+                - ASP/Agent
+                - JSP/Agent
+                - VBS/Agent
+                - Backdoor/PHP
+                - Backdoor/JSP
+                - Backdoor/ASP
+                - Backdoor/VBS
+                - Backdoor/Java
+                - PHP.Agent
+                - ASP.Agent
+                - JSP.Agent
+                - VBS.Agent
+                - Backdoor.PHP
+                - Backdoor.JSP
+                - Backdoor.ASP
+                - Backdoor.VBS
+                - Backdoor.Java
+                - PShlSpy
+                - C99shell
+    condition: antivirus and selection
+fields:
+    - FileName
+    - User
+falsepositives:
+    - Unlikely
+level: high
+ruletype: Sigma

--- a/tools/sigmac/logsource_mapping.py
+++ b/tools/sigmac/logsource_mapping.py
@@ -257,6 +257,9 @@ class LogsourceConverter:
                         new_obj["tags"].append("sysmon")
                 else:
                     new_obj["tags"] = ["sysmon"]
+            if ls.category == "antivirus":
+                new_obj['logsource']["product"] = "windows"
+                new_obj['logsource']["service"] = ls.service
             detection = copy.deepcopy(new_obj['detection'])
             # 出力時に順番を logsource -> selection -> conditionにしたいので一旦クリア
             new_obj['detection'] = dict()

--- a/tools/sigmac/windows-antivirus.yml
+++ b/tools/sigmac/windows-antivirus.yml
@@ -1,0 +1,26 @@
+title: Conversion of Antivirus rule
+logsources:
+    antivirus:
+        category: antivirus
+        conditions:
+            EventID:  # https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus IDs with existing 'Threat Name' or 'Path'
+                - 1006
+                - 1007
+                - 1008
+                - 1009
+                - 1010
+                - 1011
+                - 1012
+                - 1115
+                - 1116
+                - 1017
+                - 1018
+                - 1019
+                - 1115
+                - 1116
+        rewrite:
+            product: windows
+            service: windefend
+fieldmappings:
+    Signature: ThreatName
+    Filename: Path


### PR DESCRIPTION
## What Changed

- Fixed #456
- Added process for conversion  `antivirus category` rule

## Evidence
### Test Environment 
- OS: macOS montery version 13.1
- Hard: MacBook Air(M1, 2020) , Memory 8GB, Core 8
- Python 3.11.1

## Test1(antivirus category rule converted)
[av_exploiting.yml](https://github.com/SigmaHQ/sigma/blob/c0332a9d96f6c7804fcc85dd706caed889446a62/rules/category/antivirus/av_exploiting.yml#L1) is converted as follows. (`Signature` -> `ThreatName`)
```
title: Antivirus Exploitation Framework Detection
id: 238527ad-3c2c-4e4f-a1f6-92fd63adb864
status: stable
description: Detects a highly relevant Antivirus alert that reports an exploitation
    framework
references:
    - https://www.nextron-systems.com/?s=antivirus
    - https://www.virustotal.com/gui/file/925b0b28472d4d79b4bf92050e38cc2b8f722691c713fc28743ac38551bc3797
    - https://www.virustotal.com/gui/file/8f8daabe1c8ceb5710949283818e16c4aa8059bf2ce345e2f2c90b8692978424
    - https://www.virustotal.com/gui/file/d9669f7e3eb3a9cdf6a750eeb2ba303b5ae148a43e36546896f1d1801e912466
author: Florian Roth (Nextron Systems), Arnim Rupp
date: 2018/09/09
modified: 2023/01/13
tags:
    - attack.execution
    - attack.t1203
    - attack.command_and_control
    - attack.t1219
logsource:
    category: antivirus
    product: windows
    service: windefend
detection:
    antivirus:
        EventID:
            - 1006
            - 1007
            - 1008
            - 1009
            - 1010
            - 1011
            - 1012
            - 1115
            - 1116
            - 1017
            - 1018
            - 1019
            - 1115
            - 1116
        Channel: Microsoft-Windows-Windows Defender/Operational
    selection:
        ThreatName|contains:
            - MeteTool
            - MPreter
            - Meterpreter
            - Metasploit
            - PowerSploit
            - CobaltStrike
            - BruteR
            - Brutel
            - Swrort
            - Rozena
            - Backdoor.Cobalt
            - CobaltStr
            - COBEACON
            - Cometer
            - Razy
            - IISExchgSpawnCMD
            - Exploit.Script.CVE
            - Seatbelt
            - Sbelt
            - Sliver
    condition: antivirus and selection
fields:
    - FileName
    - User
falsepositives:
    - Unlikely
level: critical
ruletype: Sigma
```

[av_relevant_files.yml](https://github.com/SigmaHQ/sigma/blob/c0332a9d96f6c7804fcc85dd706caed889446a62/rules/category/antivirus/av_relevant_files.yml#L1) is converted as follows.(`Filename` -> `Path`)
```
title: Antivirus Relevant File Paths Alerts
id: c9a88268-0047-4824-ba6e-4d81ce0b907c
status: test
description: Detects an Antivirus alert in a highly relevant file path or with a relevant
    file name
references:
    - https://www.nextron-systems.com/?s=antivirus
author: Florian Roth (Nextron Systems), Arnim Rupp
date: 2018/09/09
modified: 2023/05/19
tags:
    - attack.resource_development
    - attack.t1588
logsource:
    category: antivirus
    product: windows
    service: windefend
detection:
    antivirus:
        EventID:
            - 1006
            - 1007
            - 1008
            - 1009
            - 1010
            - 1011
            - 1012
            - 1115
            - 1116
            - 1017
            - 1018
            - 1019
            - 1115
            - 1116
        Channel: Microsoft-Windows-Windows Defender/Operational
    selection_path:
        Path|contains:
            - C:\Windows\
            - C:\Temp\
            - C:\PerfLogs\
            - C:\Users\Public\
            - C:\Users\Default\
            - \Client\
            - \tsclient\
            - \inetpub\
            - /www/
            - apache
            - tomcat
            - nginx
            - weblogic
    selection_ext:
        Path|endswith:
            - .asax
            - .ashx
            - .asmx
            - .asp
            - .aspx
            - .bat
            - .cfm
            - .cgi
            - .chm
            - .cmd
            - .dat
            - .ear
            - .gif
            - .hta
            - .jpeg
            - .jpg
            - .jsp
            - .jspx
            - .lnk
            - .php
            - .pl
            - .png
            - .ps1
            - .psm1
            - .py
            - .pyc
            - .rb
            - .scf
            - .sct
            - .sh
            - .svg
            - .txt
            - .vbe
            - .vbs
            - .war
            - .wsf
            - .wsh
            - .xml
    condition: antivirus and (1 of selection_*)
fields:
    - ThreatName
    - User
falsepositives:
    - Unlikely
level: high
ruletype: Sigma
```

## Test2(no unnecessary diffs compared to main)
```
% diff -qr new_rule old_rule
Only in new_rule/builtin: category
% ls -la new_rule/builtin/category
total 0
drwxr-xr-x   3 fukusuke  staff    96  7  5 23:08 .
drwxr-xr-x  43 fukusuke  staff  1376  7  5 23:08 ..
drwxr-xr-x   9 fukusuke  staff   288  7  5 23:08 antivirus
% ls -la new_rule/builtin/category/antivirus
total 56
drwxr-xr-x  9 fukusuke  staff   288  7  5 23:08 .
drwxr-xr-x  3 fukusuke  staff    96  7  5 23:08 ..
-rw-r--r--  1 fukusuke  staff  1844  7  5 23:08 av_exploiting.yml
-rw-r--r--  1 fukusuke  staff  2242  7  5 23:08 av_hacktool.yml
-rw-r--r--  1 fukusuke  staff  1714  7  5 23:08 av_password_dumper.yml
-rw-r--r--  1 fukusuke  staff  1422  7  5 23:08 av_printernightmare_cve_2021_34527.yml
-rw-r--r--  1 fukusuke  staff  1795  7  5 23:08 av_ransomware.yml
-rw-r--r--  1 fukusuke  staff  2090  7  5 23:08 av_relevant_files.yml
-rw-r--r--  1 fukusuke  staff  3589  7  5 23:08 av_webshell.yml
%
```

## Test3(hayabusa no parse error)
I confirmed that parsing errors do not occur in post-conversion rules as follows.
```
hayabusa-2.6.0-all-platforms % ./hayabusa csv-timeline -d ../hayabusa-sample-evtx -r ../new_rule -o new.csv -C -q
Start time: 2023/07/05 23:43

Total event log files: 584
Total file size: 138.2 MB

Loading detections rules. Please wait.

Excluded rules: 31

Deprecated rules: 165 (4.69%) (Disabled)
Experimental rules: 1966 (55.90%)
Stable rules: 105 (2.99%)
Test rules: 1446 (41.11%)
Unsupported rules: 45 (1.28%) (Disabled)

Sigma rules: 3517
Total enabled detection rules: 3517
```
## Test4(hayabusa-sample-evtx detection increase)
I confirmed that the following `15` detections have increased in `antivirus rules`.
```
hayabusa-2.6.0-all-platforms % cat new.csv | awk -F"," '{print $5, $7}' | sort | uniq -c > new-rule-count.csv
hayabusa-2.6.0-all-platforms % cat old.csv | awk -F"," '{print $5, $7}' | sort | uniq -c > old-rule-count.csv
hayabusa-2.6.0-all-platforms % diff old-rule-count.csv new-rule-count.csv
2a3,4
>    1 "crit" "Antivirus Exploitation Framework Detection"
>    3 "crit" "Antivirus Password Dumper Detection"
24a27,29
>    8 "high" "Antivirus Hacktool Detection"
>    2 "high" "Antivirus Relevant File Paths Alerts"
>    1 "high" "Antivirus Web Shell Detection"
```

I would appreciate it if you could review🙏