### PR TITLE
feat: add rule parse error check GitHub Actions

### DIFF
--- a/.github/workflows/rule-parse-error-check.yaml
+++ b/.github/workflows/rule-parse-error-check.yaml
@@ -1,0 +1,34 @@
+name: Rule parse error check
+
+on:
+  pull_request:
+
+jobs:
+  rule-parse-error-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: clone hayabusa rule repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: hayabusa-rules
+
+      - name: clone hayabusa
+        uses: actions/checkout@v3
+        with:
+          repository: Yamato-Security/hayabusa
+          submodules: recursive
+          path: hayabusa
+
+      - name: clone hayabusa-sample-evtx
+        uses: actions/checkout@v3
+        with:
+          repository: Yamato-Security/hayabusa-sample-evtx
+          path: hayabusa-sample-evtx
+
+      - name: Set up Rust toolchain
+        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: run csv-timeline
+        run: cd hayabusa && cargo run --release -- csv-timeline -d ../hayabusa-sample-evtx -r ../hayabusa-rules -w -o timeline.csv  | grep "Rule parsing error" | wc -l | grep 0


### PR DESCRIPTION
## What Changed
- feat: #520 
- Added GitHub Actions for rule parse error check
   -  If the return value of the following command is not 0, make PullRequest an error. 
   - `cd hayabusa && cargo run --release -- csv-timeline -d ../hayabusa-sample-evtx -r ../hayabusa-rules -w -o timeline.csv  | grep "Rule parsing error" | wc -l | grep 0`
   - This action is triggered by the creation of a Pull Request

## Evidence
I have confirmed the following behavior in my repository.
- parse error
  - https://github.com/fukusuket/hayabusa-rules/actions/runs/7211316237/job/19646467384
- parse success
  - https://github.com/fukusuket/hayabusa-rules/actions/runs/7211308393/job/19646440672
 
I would appreciate it if you could review when you have time🙏