### PR TITLE
fix: add rule parse error check for auto PR

### DIFF
--- a/.github/workflows/rule-parse-error-check.yaml
+++ b/.github/workflows/rule-parse-error-check.yaml
@@ -1,6 +1,7 @@
 name: Rule parse error check
 
 on:
+  workflow_dispatch:
   pull_request:
 
 jobs:
@@ -26,9 +27,16 @@ jobs:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx
 
-      - name: Set up Rust toolchain
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: dtolnay/rust-toolchain@stable
-
       - name: run csv-timeline
-        run: cd hayabusa && cargo run --release -- csv-timeline -d ../hayabusa-sample-evtx -r ../hayabusa-rules -w -o timeline.csv  | grep "Rule parsing error" | wc -l | grep 0
+        run: |
+            cd hayabusa
+            git fetch --prune --unshallow
+            LATEST_VER=`git describe --tags --abbrev=0`
+            URL="https://github.com/Yamato-Security/hayabusa/releases/download/${LATEST_VER}/hayabusa-${LATEST_VER#v}-linux.zip"
+            mkdir tmp
+            cd tmp
+            curl -OL $URL
+            unzip *.zip
+            chmod +x hayabusa-${LATEST_VER#v}-lin-x64-gnu
+            ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv
+            ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv  -C | grep "Rule parsing error" | wc -l | grep 0

--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -40,7 +40,7 @@ jobs:
           path: hayabusa-sample-evtx
 
       - name: run csv-timeline
-      - if: inputs.rule-parse-error-check
+        if: inputs.rule-parse-error-check
         run: |
             cd hayabusa
             git fetch --prune --unshallow

--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -10,7 +10,7 @@ on:
    inputs:
      rule-parse-error-check:
        description: If true, check rule parse error
-       required: fale
+       required: false
        type: boolean
        default: true
   schedule:

--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -5,13 +5,57 @@ name: Pipeline for sigma rule updates
 
 on:
   ## This workflow is executed once a day.
-  ## I added workflow_dispatch so that you can execute this workflow from the GitHub UI. 
+  ## I added workflow_dispatch so that you can execute this workflow from the GitHub UI.
   workflow_dispatch:
+   inputs:
+     rule-parse-error-check:
+       description: If true, check rule parse error
+       required: fale
+       type: boolean
+       default: true
   schedule:
-    - cron: '0 20 * * *' 
+    - cron: '0 20 * * *'
 
 jobs:
+  rule-parse-error-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: clone hayabusa rule repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: hayabusa-rules
+
+      - name: clone hayabusa
+        uses: actions/checkout@v3
+        with:
+          repository: Yamato-Security/hayabusa
+          submodules: recursive
+          path: hayabusa
+
+      - name: clone hayabusa-sample-evtx
+        uses: actions/checkout@v3
+        with:
+          repository: Yamato-Security/hayabusa-sample-evtx
+          path: hayabusa-sample-evtx
+
+      - name: run csv-timeline
+      - if: inputs.rule-parse-error-check
+        run: |
+            cd hayabusa
+            git fetch --prune --unshallow
+            LATEST_VER=`git describe --tags --abbrev=0`
+            URL="https://github.com/Yamato-Security/hayabusa/releases/download/${LATEST_VER}/hayabusa-${LATEST_VER#v}-linux.zip"
+            mkdir tmp
+            cd tmp
+            curl -OL $URL
+            unzip *.zip
+            chmod +x hayabusa-${LATEST_VER#v}-lin-x64-gnu
+            ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv
+            ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv  -C | grep "Rule parsing error" | wc -l | grep 0
+
   updateSigmaRule:
+    needs: rule-parse-error-check
     runs-on: ubuntu-latest
     steps:
       - name: clone hayabusa rule repo


### PR DESCRIPTION
## What Changed
- Fixed #520
   - Run rule parsing error checking before automatic PR creation actions as follows
      - Download latest hayabusa release binary  
      - Run csv-timeline command
      - Check `Rule parsing error` message  in console
   - The above checks are done before automatic PR creation
      - If the check fails, do not create automatic PR

## Test
if rule `rule-parse-error-check` is `true`
- https://github.com/Yamato-Security/hayabusa-rules/actions/runs/7601027408

if rule `rule-parse-error-check` is `false`
- https://github.com/Yamato-Security/hayabusa-rules/actions/runs/7601048022

I would appreciate it if you could review when you have time🙏