### PR TITLE
feat: check for parse errors before creating PR

### DIFF
--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -20,6 +20,13 @@ jobs:
   rule-parse-error-check:
     runs-on: ubuntu-latest
     steps:
+      - name: clone sigma
+        uses: actions/checkout@v3
+        with:
+          repository: SigmaHQ/sigma
+          path: sigma-repo
+          token: ${{ secrets.GITHUB_TOKEN }} ## This is necessary for executing on a local machine by act(Local GitHub Action Runner). We have to specify the github token explicitly.
+
       - name: clone hayabusa rule repo
         uses: actions/checkout@v3
         with:
@@ -38,6 +45,20 @@ jobs:
         with:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx
+
+      - name: setup Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Update sigma rules
+        run: |
+          cd hayabusa-rules/tools/sigmac/
+          poetry install --no-root
+          poetry run python logsource_mapping.py -r ../../../sigma-repo -o ../../../converted_rules
+          cd -
+          rm -rf hayabusa-rules/sigma/
+          mkdir hayabusa-rules/sigma/
+          cp -r converted_rules/* hayabusa-rules/sigma/
 
       - name: run csv-timeline
         if: inputs.rule-parse-error-check
@@ -58,11 +79,6 @@ jobs:
     needs: rule-parse-error-check
     runs-on: ubuntu-latest
     steps:
-      - name: clone hayabusa rule repo
-        uses: actions/checkout@v3
-        with:
-          path: hayabusa-rules
-
       - name: clone sigma
         uses: actions/checkout@v3
         with:
@@ -70,11 +86,10 @@ jobs:
           path: sigma-repo
           token: ${{ secrets.GITHUB_TOKEN }} ## This is necessary for executing on a local machine by act(Local GitHub Action Runner). We have to specify the github token explicitly.
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
+      - name: clone hayabusa rule repo
+        uses: actions/checkout@v3
         with:
-          python-version: '3.10'
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          path: hayabusa-rules
 
       - name: setup Poetry
         run: |


### PR DESCRIPTION
## What Changed
- Related #580 
  - I noticed that the above PR action checks the rules **after merging the previous PR** ...
  - As a result, the incorrect rule was **merged once**, and the parsing error was **found in the second PR**.
  - This PR has been fixed so that parse errors can be detected **before merging**.

## Test
As shown below, rule-parse-error-check has been modified to check for parse errors after converting the latest Sigma rule.
- https://github.com/Yamato-Security/hayabusa-rules/actions/runs/7612852965

I would appreciate it if you could review when you have time🙏
I apologize for the inconvenience... 🙇