### PR TITLE
fix: changed  rule parse check error option required to true

### DIFF
--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -10,7 +10,7 @@ on:
    inputs:
      rule-parse-error-check:
        description: If true, check rule parse error
-       required: false
+       required: true
        type: boolean
        default: true
   schedule:


### PR DESCRIPTION
## What Changed
- Related #583
  -  changed required option to true

## Current behavior
AutoPR was working in check false mode...so I changed the required option to true.

Manually PR (`run csv-timeline` executed)
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/7631251042/job/20788784777

Auto PR(`run csv-timeline` **not** executed)
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/7617479708/job/20746564662

Sorry...I don't know if this will solve the problem, but could you please merge it once?🙏