### PR TITLE
fix: reverse GitHub actions rule-parse-error-check flag

### DIFF
--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -8,11 +8,11 @@ on:
   ## I added workflow_dispatch so that you can execute this workflow from the GitHub UI.
   workflow_dispatch:
    inputs:
-     rule-parse-error-check:
-       description: If true, check rule parse error
-       required: true
+     disable-rule-parse-error-check:
+       description: If true, disable check rule parse error
+       required: false
        type: boolean
-       default: true
+       default: false
   schedule:
     - cron: '0 20 * * *'
 
@@ -61,7 +61,7 @@ jobs:
           cp -r converted_rules/* hayabusa-rules/sigma/
 
       - name: run csv-timeline
-        if: inputs.rule-parse-error-check
+        if: ${{!inputs.disable-rule-parse-error-check }}
         run: |
             cd hayabusa
             git fetch --prune --unshallow


### PR DESCRIPTION
## What Changed
Changed `rule-parse-error-check` -> `disable-rule-parse-error-check`
- Related #588
- Related #583

Sorry... it seems that neither of the above fixes had any effect.
The default value of the bool value seems to be `false`, so I changed the flag so that it defaults to `false`.

default(disable-rule-parse-error-check=false) `run-csv` executed as follows.
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/7711076080/job/21015714517

check on(disable-rule-parse-error-check=true) `run-csv` not executed as follows.
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/7711082373/job/21015733818

I would appreciate it if you could merge it🙏