### PR TITLE
fix: add field name to default_detail.txt (Sysmon EID 13, 14)

### DIFF
--- a/config/default_details.txt
+++ b/config/default_details.txt
@@ -60,10 +60,10 @@ Microsoft-Windows-Sysmon, 9, Proc: %Image% ¦ Device: %Device% ¦ PID: %ProcessI
 Microsoft-Windows-Sysmon, 10, SrcProc: %SourceImage% ¦ TgtProc: %TargetImage% ¦ SrcUser: %SourceUser% ¦ TgtUser: %TargetUser% ¦ Access: %GrantedAccess% ¦ SrcPID: %SourceProcessId% ¦ SrcPGUID: %SourceProcessGUID% ¦ TgtPID: %TargetProcessId% ¦ TgtPGUID: %TargetProcessGUID%
 Microsoft-Windows-Sysmon, 11, Path: %TargetFilename% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
 Microsoft-Windows-Sysmon, 12, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
-Microsoft-Windows-Sysmon, 13, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ %Details% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
-Microsoft-Windows-Sysmon, 14, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ %Details% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
+Microsoft-Windows-Sysmon, 13, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ Details: %Details% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
+Microsoft-Windows-Sysmon, 14, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ NewName: %NewName% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
 Microsoft-Windows-Sysmon, 15, Path: %TargetFilename% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid% ¦ Hash: %Hash%
-Microsoft-Windows-Sysmon, 16, Config: %Configuration%
+Microsoft-Windows-Sysmon, 16, Config: %Configuration%gi
 Microsoft-Windows-Sysmon, 17, Pipe: %PipeName% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
 Microsoft-Windows-Sysmon, 18, Pipe: %PipeName% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
 Microsoft-Windows-Sysmon, 19, Op: %Operation% ¦ Namespace: %EventNamespace% ¦ Name: %Name% ¦ Query: %query% ¦ User: %User%

--- a/config/default_details.txt
+++ b/config/default_details.txt
@@ -60,8 +60,8 @@ Microsoft-Windows-Sysmon, 9, Proc: %Image% ¦ Device: %Device% ¦ PID: %ProcessI
 Microsoft-Windows-Sysmon, 10, SrcProc: %SourceImage% ¦ TgtProc: %TargetImage% ¦ SrcUser: %SourceUser% ¦ TgtUser: %TargetUser% ¦ Access: %GrantedAccess% ¦ SrcPID: %SourceProcessId% ¦ SrcPGUID: %SourceProcessGUID% ¦ TgtPID: %TargetProcessId% ¦ TgtPGUID: %TargetProcessGUID%
 Microsoft-Windows-Sysmon, 11, Path: %TargetFilename% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
 Microsoft-Windows-Sysmon, 12, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
-Microsoft-Windows-Sysmon, 13, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ Details: %Details% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
-Microsoft-Windows-Sysmon, 14, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ NewName: %NewName% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
+Microsoft-Windows-Sysmon, 13, EventType: %EventType% ¦ RegKey: %TargetObject% ¦ Details: %Details% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid% ¦ User: %User%
+Microsoft-Windows-Sysmon, 14, EventType: %EventType% ¦ OldName: %TargetObject% ¦ NewName: %NewName% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid% ¦ User: %User%
 Microsoft-Windows-Sysmon, 15, Path: %TargetFilename% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid% ¦ Hash: %Hash%
 Microsoft-Windows-Sysmon, 16, Config: %Configuration%
 Microsoft-Windows-Sysmon, 17, Pipe: %PipeName% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%

--- a/config/default_details.txt
+++ b/config/default_details.txt
@@ -63,7 +63,7 @@ Microsoft-Windows-Sysmon, 12, EventType: %EventType% ¦ TgtObj: %TargetObject% �
 Microsoft-Windows-Sysmon, 13, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ Details: %Details% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
 Microsoft-Windows-Sysmon, 14, EventType: %EventType% ¦ TgtObj: %TargetObject% ¦ NewName: %NewName% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
 Microsoft-Windows-Sysmon, 15, Path: %TargetFilename% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid% ¦ Hash: %Hash%
-Microsoft-Windows-Sysmon, 16, Config: %Configuration%gi
+Microsoft-Windows-Sysmon, 16, Config: %Configuration%
 Microsoft-Windows-Sysmon, 17, Pipe: %PipeName% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
 Microsoft-Windows-Sysmon, 18, Pipe: %PipeName% ¦ Proc: %Image% ¦ PID: %ProcessId% ¦ PGUID: %ProcessGuid%
 Microsoft-Windows-Sysmon, 19, Op: %Operation% ¦ Namespace: %EventNamespace% ¦ Name: %Name% ¦ Query: %query% ¦ User: %User%


### PR DESCRIPTION
## What Changed
- Closed #616
- Closed #617

## Test (Sysmon EID 13)
`% ./hayabusa json-timeline -d ../all-evtx/Win2022-AD -m high -o out.json -w -C --include-eid
 13`
```json
{
    "Timestamp": "2022-04-07 17:14:49.824 +09:00",
    "RuleTitle": "Disable Windows Defender Functionalities Via Registry Keys",
    "Level": "high",
    "Computer": "WIN-FPV0DSIC9O6.sigma.fr",
    "Channel": "Sysmon",
    "EventID": 13,
    "RecordID": 160653,
    "Details": {
        "EventType": "SetValue",
        "TgtObj": "HKLM\\SOFTWARE\\Microsoft\\Windows Defender\\Features\\TamperProtection",
        "Details": "DWORD (0x00000000)",
        "Proc": "C:\\Program Files\\Windows Defender\\MsMpEng.exe",
        "PID": 2936,
        "PGUID": "CB66FCBA-9D71-624E-4700-000000000200"
    },
    "ExtraFieldInfo": {
        "RuleName": "-",
        "User": "NT AUTHORITY\\SYSTEM",
        "UtcTime": "2022-04-07 08:14:49.818"
    }
}
```

## Test (Sysmon EID 14)
`% ./hayabusa json-timeline -d ../all-evtx/ -o eid-14.json -w -C --include-eid 14 -n -u -D`
```json
{
    "Timestamp": "2022-03-02 04:24:21.737 +09:00",
    "RuleTitle": "Reg Key Value Rename (Noisy)",
    "Level": "info",
    "Computer": "DESKTOP-6D0DBMB",
    "Channel": "Sysmon",
    "EventID": 14,
    "RecordID": 1098384,
    "Details": {
        "EventType": "RenameKey",
        "TgtObj": "HKLM\\SOFTWARE\\Microsoft\\Office\\ClickToRun\\VREGISTRY_FC4EF5AF-A40A-4956-9AD1-3BFA0BA62E9E",
        "NewName": "HKLM\\SOFTWARE\\Microsoft\\Office\\ClickToRun\\REGISTRY",
        "Proc": "C:\\Program Files\\Common Files\\Microsoft Shared\\ClickToRun\\OfficeClickToRun.exe",
        "PID": 8076,
        "PGUID": "6A627BFB-7265-621E-2F01-000000000300"
    },
    "ExtraFieldInfo": {
        "RuleName": "-",
        "User": "AUTORITE NT\\Système",
        "UtcTime": "2022-03-01 19:24:21.727"
    }
}
```
I would appreciate it if you could review when you have time🙏