### PR TITLE
fix: add condition clause in Windows Defender rule

### DIFF
--- a/hayabusa/builtin/WindowsDefender/Defender_1116_Crit_Alert.yml
+++ b/hayabusa/builtin/WindowsDefender/Defender_1116_Crit_Alert.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis, Fukusuke Takahashi
 date: 2021/12/01
-modified: 2023/6/17
+modified: 2024/3/20
 
 title: 'Defender Alert (Severe)'
 description: Windows defender malware detection
@@ -16,6 +16,7 @@ detection:
         Channel: Microsoft-Windows-Windows Defender/Operational
         EventID: 1116
         SeverityID: 5 # Severe
+    condition: selection
 falsepositives:
     - bad signature
 tags:

--- a/hayabusa/builtin/WindowsDefender/Defender_1116_High_Alert.yml
+++ b/hayabusa/builtin/WindowsDefender/Defender_1116_High_Alert.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis, Fukusuke Takahashi
 date: 2021/12/01
-modified: 2023/6/17
+modified: 2024/3/20
 
 title: 'Defender Alert (High)'
 description: Windows defender malware detection
@@ -16,6 +16,7 @@ detection:
         Channel: Microsoft-Windows-Windows Defender/Operational
         EventID: 1116
         SeverityID: 4 # High
+    condition: selection
 falsepositives:
     - bad signature
 tags:

--- a/hayabusa/builtin/WindowsDefender/Defender_1116_Low_Alert.yml
+++ b/hayabusa/builtin/WindowsDefender/Defender_1116_Low_Alert.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis, Fukusuke Takahashi
 date: 2021/12/01
-modified: 2023/6/17
+modified: 2024/3/20
 
 title: 'Defender Alert (Low)'
 description: 'Windows defender malware detection'
@@ -16,6 +16,7 @@ detection:
         Channel: Microsoft-Windows-Windows Defender/Operational
         EventID: 1116
         SeverityID: 2 # Low
+    condition: selection
 falsepositives:
     - bad signature
 tags:

--- a/hayabusa/builtin/WindowsDefender/Defender_1116_Med_Alert.yml
+++ b/hayabusa/builtin/WindowsDefender/Defender_1116_Med_Alert.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis, Fukusuke Takahashi
 date: 2021/12/01
-modified: 2023/6/17
+modified: 2024/3/20
 
 title: 'Defender Alert (Moderate)'
 description: 'Windows defender malware detection'
@@ -16,6 +16,7 @@ detection:
         Channel: Microsoft-Windows-Windows Defender/Operational
         EventID: 1116
         SeverityID: 3 # Moderate
+    condition: selection
 falsepositives:
     - bad signature
 tags:


### PR DESCRIPTION
## What Changed
There was no `condition` clause in the Windows Defender rules, so I added it.
- Related: https://github.com/Velocidex/velociraptor-sigma-rules/issues/24#issuecomment-2008651738

For some reason, Hayabusa seems to be able to detect it even if there is no `condition` clause... :)
I would appreciate it if you could review when you have time🙏