### PR TITLE
fix: update GitHub action's hayabusa zip name

### DIFF
--- a/.github/workflows/rule-parse-error-check.yaml
+++ b/.github/workflows/rule-parse-error-check.yaml
@@ -32,7 +32,7 @@ jobs:
             cd hayabusa
             git fetch --prune --unshallow
             LATEST_VER=`git describe --tags --abbrev=0`
-            URL="https://github.com/Yamato-Security/hayabusa/releases/download/${LATEST_VER}/hayabusa-${LATEST_VER#v}-linux.zip"
+            URL="https://github.com/Yamato-Security/hayabusa/releases/download/${LATEST_VER}/hayabusa-${LATEST_VER#v}-linux-intel.zip"
             mkdir tmp
             cd tmp
             curl -OL $URL


### PR DESCRIPTION
## What Changed
The file naming convention for hayabusa release binaries has changed and actions are failing, so we fixed it.

I would appreciate it if you could review when you have time🙏