### PR TITLE
display rule parse error log in console when rule parse error

### DIFF
--- a/.github/workflows/rule-parse-error-check.yaml
+++ b/.github/workflows/rule-parse-error-check.yaml
@@ -40,3 +40,4 @@ jobs:
             chmod +x hayabusa-${LATEST_VER#v}-lin-x64-gnu
             ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv -D -n -u
             ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv -D -n -u  -C | grep "Rule parsing error" | wc -l | grep 0
+          　if [ $? -ne 0 ]; then cat ./logs/*; false; fi

--- a/.github/workflows/rule-parse-error-check.yaml
+++ b/.github/workflows/rule-parse-error-check.yaml
@@ -40,4 +40,4 @@ jobs:
             chmod +x hayabusa-${LATEST_VER#v}-lin-x64-gnu
             ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv -D -n -u
             ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv -D -n -u  -C | grep "Rule parsing error" | wc -l | grep 0
-          　if [ $? -ne 0 ]; then cat ./logs/*; false; fi
+            if [ $? -ne 0 ]; then cat ./logs/*; false; fi


### PR DESCRIPTION
## What Changed
Added a process to `cat /logs/*` when a rule parsing error occurs :)
I would appreciate it if you could review when you have time🙏