### PR TITLE
chg: display error log when rule parse error in Github Actions

### DIFF
--- a/.github/workflows/rule-parse-error-check.yaml
+++ b/.github/workflows/rule-parse-error-check.yaml
@@ -39,5 +39,17 @@ jobs:
             unzip *.zip
             chmod +x hayabusa-${LATEST_VER#v}-lin-x64-gnu
             ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv -D -n -u
-            ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv -D -n -u  -C | grep "Rule parsing error" | wc -l | grep 0
-            if [ $? -ne 0 ]; then cat ./logs/*; false; fi
+
+      - name: check csv-timeline result
+        shell: /usr/bin/bash {0}
+        run: |
+          cd hayabusa
+          LATEST_VER=`git describe --tags --abbrev=0`
+          cd tmp
+          ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv -D -n -u  -C | grep "Rule parsing error" | wc -l | grep 0
+          if [ $? -eq 0 ]; then
+              echo "No rule parse error."
+          else
+              cat ./logs/*
+              false
+          fi


### PR DESCRIPTION
## What Changed
Added a process to `cat /logs/*` when a rule parsing error occurs :)
- Added `check csv-timeline result` step to check which rule is causing the error

## Test
I confirmed that actions work as expected with and without errors.

#### If there is a parse error
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/8654207238/job/23730955165#step:6:15

#### If there is no parse error
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/8654376592/job/23731472288#step:6:15

I would appreciate it if you could review when you have time🙏