### PR TITLE
chg: output error log when rule parse error

### DIFF
--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -73,7 +73,21 @@ jobs:
             unzip *.zip
             chmod +x hayabusa-${LATEST_VER#v}-lin-x64-gnu
             ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv
-            ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv  -C | grep "Rule parsing error" | wc -l | grep 0
+
+      - name: check csv-timeline result
+        if: ${{!inputs.disable-rule-parse-error-check }}
+        shell: /usr/bin/bash {0}
+        run: |
+          cd hayabusa
+          LATEST_VER=`git describe --tags --abbrev=0`
+          cd tmp
+          ./hayabusa-${LATEST_VER#v}-lin-x64-gnu csv-timeline -d ../../hayabusa-sample-evtx -r ../../hayabusa-rules -w -o out.csv -D -n -u  -C | grep "Rule parsing error" | wc -l | grep 0
+          if [ $? -eq 0 ]; then
+              echo "No rule parse error."
+          else
+              cat ./logs/*
+              false
+          fi
 
   updateSigmaRule:
     needs: rule-parse-error-check


### PR DESCRIPTION
## What Changed
Sorry, I forget to add step in `Pipeline for sigma rule updates` ... so I added it.

I confirmed `check csv-timeline result` works as follows.
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/8656500120/job/23737111544#step:9:15

I would appreciate it if you could review when you have time🙏