### PR TITLE
fix: update duplicated actions libraries

### DIFF
--- a/.github/workflows/rule-parse-error-check.yaml
+++ b/.github/workflows/rule-parse-error-check.yaml
@@ -9,20 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: clone hayabusa rule repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: hayabusa-rules
 
       - name: clone hayabusa
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Yamato-Security/hayabusa
           submodules: recursive
           path: hayabusa
 
       - name: clone hayabusa-sample-evtx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx

--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -169,7 +169,7 @@ jobs:
 
       - name: upload change log
         if: env.change_exist == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: changed_rule_log
           path: ${{ github.workspace }}/changed_rule.logs

--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -21,27 +21,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: clone sigma
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: SigmaHQ/sigma
           path: sigma-repo
           token: ${{ secrets.GITHUB_TOKEN }} ## This is necessary for executing on a local machine by act(Local GitHub Action Runner). We have to specify the github token explicitly.
 
       - name: clone hayabusa rule repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: hayabusa-rules
 
       - name: clone hayabusa
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Yamato-Security/hayabusa
           submodules: recursive
           path: hayabusa
 
       - name: clone hayabusa-sample-evtx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx
@@ -94,14 +94,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: clone sigma
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: SigmaHQ/sigma
           path: sigma-repo
           token: ${{ secrets.GITHUB_TOKEN }} ## This is necessary for executing on a local machine by act(Local GitHub Action Runner). We have to specify the github token explicitly.
 
       - name: clone hayabusa rule repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: hayabusa-rules
 
@@ -147,7 +147,7 @@ jobs:
       - name: Create Pull Request
         if: env.change_exist == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           path: hayabusa-rules
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created' # This only runs if there were sigma rules updates and a new PR was created.
-        uses: peter-evans/enable-pull-request-automerge@v2
+        uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/sigma/sysmon/network_connection/net_connection_win_dialer_initiated_connection.yml
+++ b/sigma/sysmon/network_connection/net_connection_win_dialer_initiated_connection.yml
@@ -1,0 +1,46 @@
+title: Outbound Network Connection Initiated By Microsoft Dialer
+id: 867373a9-7f8b-1d28-0c6b-770fc707dbbb
+related:
+    - id: 37e4024a-6c80-4d8f-b95d-2e7e94f3a8d1
+      type: derived
+status: experimental
+description: |
+    Detects outbound network connection initiated by Microsoft Dialer.
+    The Microsoft Dialer, also known as Phone Dialer, is a built-in utility application included in various versions of the Microsoft Windows operating system. Its primary function is to provide users with a graphical interface for managing phone calls via a modem or a phone line connected to the computer.
+    This is an outdated process in the current conext of it's usage and is a common target for info stealers for process injection, and is used to make C2 connections, common example is "Rhadamanthys"
+references:
+    - hhttps://tria.ge/240301-rk34sagf5x/behavioral2
+    - https://app.any.run/tasks/6720b85b-9c53-4a12-b1dc-73052a78477d
+    - https://research.checkpoint.com/2023/rhadamanthys-v0-5-0-a-deep-dive-into-the-stealers-components/
+    - https://strontic.github.io/xcyclopedia/library/dialer.exe-0B69655F912619756C704A0BF716B61F.html
+author: CertainlyP
+date: 2024/04/26
+tags:
+    - attack.execution
+    - attack.t1071.001
+    - sysmon
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    network_connection:
+        EventID: 3
+        Channel: Microsoft-Windows-Sysmon/Operational
+    selection:
+        Image|endswith: :\Windows\System32\dialer.exe
+        Initiated: 'true'
+    filter_main_local_ranges:
+        DestinationIp|cidr:
+            - 127.0.0.0/8
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+            - 169.254.0.0/16
+            - ::1/128    # IPv6 loopback
+            - fe80::/10    # IPv6 link-local addresses
+            - fc00::/7    # IPv6 private addresses
+    condition: network_connection and (selection and not 1 of filter_main_*)
+falsepositives:
+    - In Modern Windows systems, unable to see legitimate usage of this process, However, if an organization has legitimate purpose for this there can be false positives.
+level: high
+ruletype: Sigma


### PR DESCRIPTION
## What Changed
- Closed #653 
    - actions/checkout@v3 -> v4
    - peter-evans/create-pull-request@v4 -> v6
    - peter-evans/enable-pull-request-automerge@v2 -> v3

I would like to check whether the PR is created correctly when the Sigma rules are updated.