### PR TITLE
fix: declare `Channel` explicitly

### DIFF
--- a/hayabusa/builtin/PowerShell_Op/PwSh_4103_Info_PipelineExecution.yml
+++ b/hayabusa/builtin/PowerShell_Op/PwSh_4103_Info_PipelineExecution.yml
@@ -14,8 +14,9 @@ logsource:
     description: Powershell module logging needs to be turned on.
 detection:
     select_channel:
-        - Microsoft-Windows-PowerShell/Operational
-        - PowerShellCore/Operational
+        Channel:
+            - Microsoft-Windows-PowerShell/Operational
+            - PowerShellCore/Operational
     select_eid:
         EventID: 4103
     condition: select_channel and select_eid

--- a/hayabusa/builtin/PowerShell_Op/PwSh_4103_Info_PipelineExecution.yml
+++ b/hayabusa/builtin/PowerShell_Op/PwSh_4103_Info_PipelineExecution.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2020/11/08
-modified: 2023/03/31
+modified: 2024/04/29
 
 title: PwSh Pipeline Exec
 description: Powershell Module Loggong. Displays powershell execution

--- a/hayabusa/builtin/PowerShell_Op/PwSh_4104_Info_ScriptblockLog.yml
+++ b/hayabusa/builtin/PowerShell_Op/PwSh_4104_Info_ScriptblockLog.yml
@@ -16,8 +16,9 @@ logsource:
     description: Powershell script block logging needs to be turned on.
 detection:
     select_channel:
-        - Microsoft-Windows-PowerShell/Operational
-        - PowerShellCore/Operational
+        Channel:
+            - Microsoft-Windows-PowerShell/Operational
+            - PowerShellCore/Operational
     select_eid:
         EventID: 4104
     filter_level_warning:

--- a/hayabusa/builtin/PowerShell_Op/PwSh_4104_Info_ScriptblockLog.yml
+++ b/hayabusa/builtin/PowerShell_Op/PwSh_4104_Info_ScriptblockLog.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2020/11/08
-modified: 2023/03/31
+modified: 2024/04/29
 
 title: PwSh Scriptblock
 description: |

--- a/hayabusa/builtin/PowerShell_Op/PwSh_4104_Med_ScriptblockLog_PotentiallyMalicious.yml
+++ b/hayabusa/builtin/PowerShell_Op/PwSh_4104_Med_ScriptblockLog_PotentiallyMalicious.yml
@@ -14,8 +14,9 @@ logsource:
     description: Default with PwSh 5+ (Ex. Win 10+)
 detection:
     select_channel:
-        - Microsoft-Windows-PowerShell/Operational
-        - PowerShellCore/Operational
+        Channel:
+            - Microsoft-Windows-PowerShell/Operational
+            - PowerShellCore/Operational
     select_eid:
         EventID: 4104
     select_level_warning:

--- a/hayabusa/builtin/PowerShell_Op/PwSh_4104_Med_ScriptblockLog_PotentiallyMalicious.yml
+++ b/hayabusa/builtin/PowerShell_Op/PwSh_4104_Med_ScriptblockLog_PotentiallyMalicious.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2020/11/08
-modified: 2023/03/31
+modified: 2024/04/29
 
 title: Potentially Malicious PwSh
 description: 'On Powershell v5+, Windows will automatically log suspicious powershell execution and mark the Level as Warning.'


### PR DESCRIPTION
## What Changed
Fixed a rule where `Channel` was not specified.
When implementing https://github.com/Yamato-Security/hayabusa/issues/1317 , the `Channel` must be specified explicitly.

## Test
I confirmed that there is no difference in the number of detections before and after the modification as shown below.

after:
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/8871225497/job/24353898756#step:5:4856

before:
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/8871253258/job/24353962845#step:5:4856

I would appreciate it if you could review when you have time🙏