### PR TITLE
feat: add `sigma-to-hayabusa-converter` repo branch checkout option

### DIFF
--- a/.github/workflows/update-sigmarule.yaml
+++ b/.github/workflows/update-sigmarule.yaml
@@ -13,6 +13,11 @@ on:
        required: false
        type: boolean
        default: false
+     sigma_to_hayabusa_converter_branch:
+       description: Branch to use for sigma-to-hayabusa-converter
+       required: false
+       type: string
+       default: main
   schedule:
     - cron: '0 20 * * *'
 
@@ -45,6 +50,7 @@ jobs:
         with:
           repository: Yamato-Security/sigma-to-hayabusa-converter
           path: sigma-to-hayabusa-converter
+          ref: ${{ github.event.inputs.sigma_to_hayabusa_converter_branch }}
 
       - name: clone hayabusa-sample-evtx
         uses: actions/checkout@v3
@@ -116,6 +122,7 @@ jobs:
         with:
           repository: Yamato-Security/sigma-to-hayabusa-converter
           path: sigma-to-hayabusa-converter
+          ref: ${{ github.event.inputs.sigma_to_hayabusa_converter_branch }}
 
       - name: setup Poetry
         run: |


### PR DESCRIPTION
## What Changed

Modified Actions to allow optional selection of branches in the sigma-to-hayabusa-converter repository to test the functionality of branches in sigma-to-hayabusa-converter

### How to use
Enter the name of the branch to be tested in the sigma-to-hayabusa-converter repository.
<img width="1235" alt="スクリーンショット 2024-07-30 17 45 50" src="https://github.com/user-attachments/assets/864bc7b3-7b07-4345-87c1-45da6622aac2">

I would appreciate it if you could check it out when you have time🙏