### PR TITLE
Fix: Delete unnecessary duplicate key (`sample-evtx`) in rule

### DIFF
--- a/hayabusa/sysmon/Sysmon_1_Info_ProcExec.yml
+++ b/hayabusa/sysmon/Sysmon_1_Info_ProcExec.yml
@@ -26,7 +26,6 @@ tags:
     - sysmon
 references:
     - https://github.com/trustedsec/SysmonCommunityGuide/blob/master/chapters/process-creation.md
-sample-evtx: 
 ruletype: Hayabusa
 
 sample-evtx: |


### PR DESCRIPTION
There was a duplicate key(`sample-evtx`) that has been corrected.
(This is invalid as YAML and will result in a parse error)

I would appreciate it if you could check it out when you have time🙏