### PR TITLE
chg: If there is no difference, do not create SupportedSigmaFieldModifiers.md

### DIFF
--- a/scripts/supported_modifiers_check/supported-modifier.py
+++ b/scripts/supported_modifiers_check/supported-modifier.py
@@ -90,10 +90,16 @@ if __name__ == '__main__':
     markdown_str = markdown_str + pd.DataFrame(sorted(result_supported), columns=header).to_markdown(index=False)
     markdown_str = markdown_str + "\n\n# Hayabusa unsupported field modifiers\n"
     markdown_str = markdown_str + pd.DataFrame(sorted(result_unsupported), columns=header).to_markdown(index=False)
-    markdown_str = f"{markdown_str}\n\nUpdated: {datetime.datetime.now().strftime('%Y/%m/%d')}  \nAuthor: Fukusuke Takahashi"
-    Path(args.out_path).write_text(markdown_str)
-
+    current_markdown = Path(args.out_path)
+    if current_markdown.exists():
+        current_str = current_markdown.read_text(encoding='utf-8')
+        current_str = re.sub(r"Updated:.*", "", current_str, flags=re.DOTALL).strip()
+        if current_str == markdown_str.strip():
+            logging.info("No changes detected in the report. Skipping file write.")
+        else:
+            markdown_str = f"{markdown_str}\n\nUpdated: {datetime.datetime.now().strftime('%Y/%m/%d')}  \nAuthor: Fukusuke Takahashi"
+            Path(args.out_path).write_text(markdown_str)
+            logging.info(f'Markdown report generated and saved to {args.out_path}')
     end_time = time.time()
     execution_time = end_time - start_time
-    logging.info(f'Markdown report generated and saved to {args.out_path}')
     logging.info(f'Script execution completed in {execution_time:.2f} seconds')


### PR DESCRIPTION
## What Changed
Fixed to not create a new file when there is no difference in the SupportedSigmaFieldModifiers.md.

## Test
### When there is no difference
```
poetry run python supported-modifier.py ../../../sigma ../../../hayabusa-rules ../../doc/SupportedSigmaFieldModifiers.md
2024-09-06 18:28:34,651 - INFO - Starting script execution: supported-modifier.py
2024-09-06 18:28:34,652 - INFO - Starting to process YAML files in directory: ../../../sigma
2024-09-06 18:28:43,290 - INFO - Finished processing YAML files
2024-09-06 18:28:43,291 - INFO - Starting to process YAML files in directory: ../../../hayabusa-rules
2024-09-06 18:28:56,453 - INFO - Finished processing YAML files
2024-09-06 18:28:56,459 - INFO - No changes detected in the report. Skipping file write.
2024-09-06 18:28:56,459 - INFO - Script execution completed in 21.81 seconds
```

### When there are difference
```
 poetry run python supported-modifier.py ../../../sigma ../../../hayabusa-rules ../../doc/SupportedSigmaFieldModifiers.md
2024-09-06 18:31:31,393 - INFO - Starting script execution: supported-modifier.py
2024-09-06 18:31:31,394 - INFO - Starting to process YAML files in directory: ../../../sigma
2024-09-06 18:31:39,866 - INFO - Finished processing YAML files
2024-09-06 18:31:39,868 - INFO - Starting to process YAML files in directory: ../../../hayabusa-rules
2024-09-06 18:31:53,002 - INFO - Finished processing YAML files
2024-09-06 18:31:53,007 - INFO - Markdown report generated and saved to ../../doc/SupportedSigmaFieldModifiers.md
2024-09-06 18:31:53,008 - INFO - Script execution completed in 21.61 seconds
```
I would appreciate it if you could check it out when you have time🙏
