### PR TITLE
feat: add RDS Session Reconnect rule (EID:25)

### DIFF
--- a/hayabusa/builtin/Security/LogonLogoff/OtherLogonLogoffEvents/Sec_4778_Info_RDP-SessReconn.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/OtherLogonLogoffEvents/Sec_4778_Info_RDP-SessReconn.yml
@@ -2,7 +2,7 @@ author: Zach Mathis
 date: 2022/03/29
 modified: 2023/01/11
 
-title: RDP Session Reconnect
+title: RDP Sess Reconnect
 description: 'Detects when there is a RDP session reconnect.'
 
 id: db23f704-61c8-4c95-a5b7-4db61c89f41d

--- a/hayabusa/builtin/Security/LogonLogoff/OtherLogonLogoffEvents/Sec_4778_Info_RDP-SessReconn.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/OtherLogonLogoffEvents/Sec_4778_Info_RDP-SessReconn.yml
@@ -2,7 +2,7 @@ author: Zach Mathis
 date: 2022/03/29
 modified: 2023/01/11
 
-title: RDP Sess Reconnect
+title: RDP Session Reconnect
 description: 'Detects when there is a RDP session reconnect.'
 
 id: db23f704-61c8-4c95-a5b7-4db61c89f41d

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_25_Info_RDS-SessReconn.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_25_Info_RDS-SessReconn.yml
@@ -1,0 +1,57 @@
+author: Fukusuke Takahashi
+date: 2024/11/03
+
+title: RDS Session Reconnect
+details: "User: %UserDataUser% ¦ SessID: %UserDataSessionID% ¦ SrcIP: %UserDataAddress%"
+description:
+references:
+  - https://jpcertcc.github.io/ToolAnalysisResultSheet_jp/details/mstsc.htm
+id: 8fe4a60b-2af3-43d6-95e2-8f13caccc179
+level: informational
+status: test
+logsource:
+    product: windows
+detection:
+    selection:
+        Channel: "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational"
+        EventID: 25
+    condition: selection
+falsepositives:
+    - administrator
+tags:
+    - RDP
+    - attack.lateral_movement
+ruletype: Hayabusa
+
+sample-message: |
+  Remote Desktop Services: Session reconnection succeeded:
+
+  User: samurai\hayabusa
+  Session ID: 3
+  Source Network Address: 203.0.113.1
+sample-evtx: |
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
+        <System> 
+            <Provider Name="Microsoft-Windows-TerminalServices-LocalSessionManager" Guid="{5d896912-022d-40aa-a3a8-4fa5515c76d7}" /> 
+            <EventID>25</EventID> 
+            <Version>0</Version> 
+            <Level>4</Level> 
+            <Task>0</Task> 
+            <Opcode>0</Opcode> 
+            <Keywords>0x1000000000000000</Keywords> 
+            <TimeCreated SystemTime="2024-11-03T07:36:59.0226807Z" /> 
+            <EventRecordID>88</EventRecordID> 
+            <Correlation ActivityID="{f420125d-74d2-4a42-acdf-984926b10000}" /> 
+            <Execution ProcessID="904" ThreadID="1844" /> 
+            <Channel>Microsoft-Windows-TerminalServices-LocalSessionManager/Operational</Channel> 
+            <Computer>samurai</Computer> 
+            <Security UserID="S-1-5-18" /> 
+        </System> 
+        <UserData> 
+            <EventXML xmlns="Event_NS"> 
+              <User>samurai\hayabusa</User> 
+              <SessionID>3</SessionID> 
+              <Address>203.0.113.1</Address> 
+            </EventXML> 
+        </UserData> 
+    </Event>

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_25_Info_RDS-SessReconn.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_25_Info_RDS-SessReconn.yml
@@ -1,7 +1,7 @@
 author: Fukusuke Takahashi
 date: 2024/11/03
 
-title: RDS Session Reconnect
+title: RDS Sess Reconnect
 details: "User: %UserDataUser% ¦ SessID: %UserDataSessionID% ¦ SrcIP: %UserDataAddress%"
 description:
 references:


### PR DESCRIPTION
## What Changed
- Related https://github.com/Yamato-Security/hayabusa/issues/1468
    - Added rule for EID:25, which is output when reconnecting to a previous RDP session without logging out.

### sample evtx msg
```
Remote Desktop Services: Session reconnection succeeded:

User: samurai\hayabusa
Session ID: 3
Source Network Address: 203.0.113.1
```

### sample evtx xml
```xml
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event"> 
    <System> 
        <Provider Name="Microsoft-Windows-TerminalServices-LocalSessionManager" Guid="{5d896912-022d-40aa-a3a8-4fa5515c76d7}" /> 
        <EventID>25</EventID> 
        <Version>0</Version> 
        <Level>4</Level> 
        <Task>0</Task> 
        <Opcode>0</Opcode> 
        <Keywords>0x1000000000000000</Keywords> 
        <TimeCreated SystemTime="2024-11-03T07:36:59.0226807Z" /> 
        <EventRecordID>88</EventRecordID> 
        <Correlation ActivityID="{f420125d-74d2-4a42-acdf-984926b10000}" /> 
        <Execution ProcessID="904" ThreadID="1844" /> 
        <Channel>Microsoft-Windows-TerminalServices-LocalSessionManager/Operational</Channel> 
        <Computer>samurai</Computer> 
        <Security UserID="S-1-5-18" /> 
    </System> 
    <UserData> 
        <EventXML xmlns="Event_NS"> 
          <User>samurai\hayabusa</User> 
          <SessionID>3</SessionID> 
          <Address>203.0.113.1</Address> 
        </EventXML> 
    </UserData> 
</Event>
```

###  Hayabusa result
```
C:\Users\hayabusa\Downloads\hayabusa-2.18.0-win-x64-live-response>hayabusa-2.18.0-win-x64.exe csv-timeline -l -w -e informational --include-eid 21,22,23,24,25,4624,4625 -s -p super-verbose --timeline-offset 20m -r sample.yml  -q
Start time: 2024/11/03 07:51

Total event log files: 367
Total file size: 62.9 MB

Loading detection rules. Please wait.


Test rules: 1 (100.00%)

Hayabusa rules: 1
Total detection rules: 1

Creating the channel filter. Please wait.

Evtx files loaded after channel filter: 1
Detection rules enabled after channel filter: 1

Output profile: super-verbose

Scanning in progress. Please wait.

[00:00:00] 1 / 1   [========================================] 100%

Scanning finished. Please wait while the results are being saved.


Timestamp · RuleTitle · Level · Computer · Channel · EventID · RuleAuthor · RuleModifiedDate · Status · RecordID · Details · ExtraFieldInfo · MitreTactics · MitreTags · OtherTags · Provider · RuleCreationDate · RuleFile · EvtxFile
2024-11-03 07:34:08.563 +00:00 · RDS Session Reconnect · info · samurai · RDS-LSM · 25 · Fukusuke Takahashi · - · test · 84 · User: samurai\hayabusa ¦ SessID: 3 ¦ SrcIP: 203.0.113.1 · - ·  ·  · RDP ¦ attack.lateral_movement · RDS-LSM · 2024/11/03 · sample.yml · C:\Windows/System32\winevt\Logs\Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx
2024-11-03 07:36:59.022 +00:00 · RDS Session Reconnect · info · samurai · RDS-LSM · 25 · Fukusuke Takahashi · - · test · 88 · User: samurai\hayabusa ¦ SessID: 3 ¦ SrcIP: 203.0.113.1 · - ·  ·  · RDP ¦ attack.lateral_movement · RDS-LSM · 2024/11/03 · sample.yml · C:\Windows/System32\winevt\Logs\Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx


Rule Authors:

╭────────────────────────╮
│ Fukusuke Takahashi (1) │
╰────────────────────────╯

Results Summary:

Events with hits / Total events: 2 / 88 (Data reduction: 86 events (97.73%))

Total | Unique detections: 2 | 1
Total | Unique critical detections: 0 (0.00%) | 0 (0.00%)
Total | Unique high detections: 0 (0.00%) | 0 (100.00%)
Total | Unique medium detections: 0 (0.00%) | 0 (0.00%)
Total | Unique low detections: 0 (0.00%) | 0 (0.00%)
Total | Unique informational detections: 2 (100.00%) | 1 (0.00%)

Dates with most total detections:
critical: n/a, high: n/a, medium: n/a, low: n/a, informational: 2024-11-03 (2)

Top 5 computers with most unique detections:
critical: n/a
high: n/a
medium: n/a
low: n/a
informational: samurai (1)

╭──────────────────────────────────────────────╮
│ Top critical alerts:        Top high alerts: │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Top medium alerts:          Top low alerts:  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ Top informational alerts:                    │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ RDS Session Reconnect (2)   n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
│ n/a                         n/a              │
╰───────────────────────────╌──────────────────╯


Elapsed time: 00:00:00.324

Please report any issues with Hayabusa rules to: https://github.com/Yamato-Security/hayabusa-rules/issues
Please report any false positives with Sigma rules to: https://github.com/SigmaHQ/sigma/issues
Please submit new Sigma rules with pull requests to: https://github.com/SigmaHQ/sigma/pulls
```