### PR TITLE
chg: add `Microsoft-Windows-TerminalServices-Gateway/Operational` abbreviation

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -246,6 +246,7 @@ sample-evtx: |
 - `Exec` -> Execution
 - `FP` -> False Positive
 - `FW` -> Firewall
+- `GTW` -> Gateway
 - `Grp` -> Group
 - `Img` -> Image
 - `Inj` -> Injection

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The following abbreviations are used in rules in order to make the output as con
 - `Exec` -> Execution
 - `FP` -> False Positive
 - `FW` -> Firewall
+- `GTW` -> Gateway
 - `Grp` -> Group
 - `Img` -> Image
 - `Inj` -> Injection

--- a/config/channel_abbreviations.txt
+++ b/config/channel_abbreviations.txt
@@ -41,6 +41,7 @@ Microsoft-Windows-User Profile Service/Operational,UserProfileSvc
 Microsoft-Windows-WindowsSystemAssessmentTool/Operational,WinSysAssessmentTool
 Microsoft-Windows-Resource-Exhaustion-Detector/Operational,RescourceExhaustionDetector
 Microsoft-Windows-Kernel-WHEA/Operational,KernelWHEA
+Microsoft-Windows-TerminalServices-Gateway/Operational,RDS-GTW
 Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational,RDS-RCM
 Microsoft-Windows-TerminalServices-LocalSessionManager/Operational,RDS-LSM
 PowerShellCore,PwShCore

--- a/config/provider_abbreviations.txt
+++ b/config/provider_abbreviations.txt
@@ -2,6 +2,7 @@ Provider,Abbreviation
 Microsoft-Windows-Security-Auditing,Sec
 Microsoft-Windows-Sysmon,Sysmon
 Microsoft-Windows-TaskScheduler,TaskScheduler
+Microsoft-Windows-TerminalServices-Gateway/Operational,RDS-GTW
 Microsoft-Windows-TerminalServices-LocalSessionManager,RDS-LSM
 Microsoft-Windows-TerminalServices-RemoteConnectionManager,RDS-RCM
 Microsoft-Windows-WMI-Activity,WMI-Activity


### PR DESCRIPTION
## What Changed
- Added `Microsoft-Windows-TerminalServices-Gateway/Operational` abbreviation
- Related https://github.com/Yamato-Security/hayabusa/issues/1468

I would appreciate it if you could check it out when you have time🙏