### PR TITLE
make the levels consistent for correlation referenced rules

### DIFF
--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_UserGuessing_Correlation.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_UserGuessing_Correlation.yml
@@ -60,7 +60,7 @@ detection:
         IpAddress: "-"
     condition: selection and not filter
 falsepositives:
-level: informational
+level: medium
 ruletype: Hayabusa
 
 sample-evtx: |

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_WrongPW_PW-Guessing_Correlation.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_WrongPW_PW-Guessing_Correlation.yml
@@ -59,7 +59,7 @@ detection:
        - TargetUserName|endswith: "$"
     condition: selection and not filter
 falsepositives:
-level: informational
+level: medium
 ruletype: Hayabusa
 
 sample-evtx: |

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_PW-Spray_Correlation.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_PW-Spray_Correlation.yml
@@ -53,5 +53,5 @@ detection:
        - IpAddress: "-"
     condition: selection and not filter
 falsepositives:
-level: informational
+level: medium
 ruletype: Hayabusa


### PR DESCRIPTION
I noticed that if you run Hayabusa with a minimum alert level of say `medium`, then the correlation rules with a level of `medium` will get a parsing error because the referenced rules were set to `informational`

Ex:
```
[WARN] Failed to parse rule. (FilePath : rules/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_PW-Spray_Correlation.yml) The referenced rule was not found: explicit_logon
[WARN] Failed to parse rule. (FilePath : rules/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_UserGuessing_Correlation.yml) The referenced rule was not found: non_existent_user
[WARN] Failed to parse rule. (FilePath : rules/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_WrongPW_PW-Guessing_Correlation.yml) The referenced rule was not found: incorrect_password
```

Since the referenced rules are only meant to be outputted when debugging the rule, I think I will just make sure the referenced rules have the same level as the correlation rule.