### PR TITLE
chg: add supported modifier (`contains|cased`, `startswith|cased`, `endswith|cased`)

### DIFF
--- a/doc/SupportedSigmaFieldModifiers.md
+++ b/doc/SupportedSigmaFieldModifiers.md
@@ -5,7 +5,7 @@
 | base64offsetǀcontains         |             7 |                0 |
 | cased                         |             0 |                0 |
 | cidr                          |            34 |                0 |
-| contains                      |          2761 |               21 |
+| contains                      |          2764 |               21 |
 | containsǀall                  |           977 |                0 |
 | containsǀallǀwindash          |             4 |                0 |
 | containsǀcased                |             0 |                0 |

--- a/doc/SupportedSigmaFieldModifiers.md
+++ b/doc/SupportedSigmaFieldModifiers.md
@@ -5,12 +5,14 @@
 | base64offsetǀcontains         |             7 |                0 |
 | cased                         |             0 |                0 |
 | cidr                          |            34 |                0 |
-| contains                      |          2764 |               21 |
+| contains                      |          2761 |               21 |
 | containsǀall                  |           977 |                0 |
 | containsǀallǀwindash          |             4 |                0 |
+| containsǀcased                |             0 |                0 |
 | containsǀwindash              |            78 |                0 |
 | endswith                      |          2915 |              271 |
 | endswithfield                 |             0 |                0 |
+| endswithǀcased                |             0 |                0 |
 | endswithǀwindash              |             2 |                0 |
 | equalsfield                   |             0 |                0 |
 | exists                        |             0 |                0 |
@@ -27,6 +29,7 @@
 | reǀm                          |             0 |                0 |
 | reǀs                          |             0 |                0 |
 | startswith                    |           443 |                6 |
+| startswithǀcased              |             0 |                0 |
 | utf16beǀbase64offsetǀcontains |             0 |                0 |
 | utf16leǀbase64offsetǀcontains |             0 |                0 |
 | utf16ǀbase64offsetǀcontains   |             0 |                0 |
@@ -53,5 +56,5 @@
 | temporal_count (with group-by) |             0 |                0 |
 
 This document is being dynamically updated based on the latest rules.  
-Last Update: 2024/11/26  
+Last Update: 2024/11/27  
 Author: Fukusuke Takahashi

--- a/scripts/supported_modifiers_check/supported-modifier.py
+++ b/scripts/supported_modifiers_check/supported-modifier.py
@@ -62,7 +62,7 @@ def get_yml_detection_counts(dir_path: str) -> (Counter, Counter):
     logging.info('Finished processing YAML files')
 
     sigma_modifiers = [
-        'all', 'startswith', 'endswith', 'contains', 'exists', 'cased', 'windash', 're', 're|i', 're|m', 're|s',
+        'all', 'startswith', 'endswith', 'contains', 'exists', 'cased', "contains|cased", "startswith|cased", "endswith|cased", 'windash', 're', 're|i', 're|m', 're|s',
         'base64', 'base64offset', 'utf16le|base64offset|contains', 'utf16be|base64offset|contains', 'utf16|base64offset|contains', 'wide|base64offset|contains',
         'lt', 'lte', 'gt', 'gte', 'cidr', 'expand', 'fieldref', 'fieldref|startswith', 'fieldref|contains','fieldref|endswith', 'equalsfield', 'endswithfield'
     ]


### PR DESCRIPTION
## What Changed
Added `contains|cased`, `startswith|cased`, `endswith|cased` to markdown.
- https://github.com/Yamato-Security/sigma-to-hayabusa-converter/pull/30#issuecomment-2502102250

### Test
```
fukusuke@fukusukenoMacBook-Air supported_modifiers_check % poetry run python supported-modifier.py ../../../sigma ../../../hayabusa-rules ../../doc/SupportedSigmaFieldModifiers.md
2024-11-27 08:48:03,252 - INFO - Starting script execution: supported-modifier.py
2024-11-27 08:48:03,253 - INFO - Starting to process YAML files in directory: ../../../sigma
2024-11-27 08:48:11,902 - INFO - Finished processing YAML files
2024-11-27 08:48:11,903 - INFO - Starting to process YAML files in directory: ../../../hayabusa-rules
2024-11-27 08:48:25,107 - INFO - Finished processing YAML files
2024-11-27 08:48:25,114 - INFO - Markdown report generated and saved to ../../doc/SupportedSigmaFieldModifiers.md
2024-11-27 08:48:25,114 - INFO - Script execution completed in 21.86 seconds
fukusuke@fukusukenoMacBook-Air supported_modifiers_check % 
```

I would appreciate it if you could check it out when you have time🙏