### PR TITLE
fix: specify ubuntu 22.04 explicitly in GitHub Actions updateMarkDown

### DIFF
--- a/.github/workflows/supported_modifier.yaml
+++ b/.github/workflows/supported_modifier.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   updateMarkDown:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone Sigma
         uses: actions/checkout@v4


### PR DESCRIPTION
Closed #812 

I confirmed fixed actions create PR successfully as follows.
https://github.com/Yamato-Security/hayabusa-rules/actions/runs/13052809273
https://github.com/Yamato-Security/hayabusa-rules/pull/813

I would appreciate it if you could check it out when you have time🙏