### PR TITLE
underscores to hyphens

### DIFF
--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -47,7 +47,7 @@ Windowsのイベントログから攻撃を検出するキュレーションさ�
   - [フィールド修飾子 (Field Modifiers)](#フィールド修飾子-field-modifiers)
     - [対応しているSigmaのフィールド修飾子](#対応しているsigmaのフィールド修飾子)
     - [非推奨のフィールド修飾子](#非推奨のフィールド修飾子)
-    - [Expandフィールド修飾子](#Expandフィールド修飾子)
+    - [Expandフィールド修飾子](#expandフィールド修飾子)
   - [ワイルドカード](#ワイルドカード)
   - [null keyword](#null-keyword)
   - [condition (条件)](#condition-条件)
@@ -70,12 +70,13 @@ Windowsのイベントログから攻撃を検出するキュレーションさ�
     - [Temporal Proximity相関ルール:](#temporal-proximity相関ルール)
   - [Ordered Temporal Proximityルール](#ordered-temporal-proximityルール)
     - [Ordered Temporal Proximityルールの例:](#ordered-temporal-proximityルールの例)
-    - [Ordered Temporal Proximity相関ルール](#ordered-temporal-proximity相関ルール)
+    - [Ordered Temporal Proximity相関ルール:](#ordered-temporal-proximity相関ルール)
   - [相関ルールの注意点](#相関ルールの注意点)
 - [非推奨機能](#非推奨機能)
   - [イベントキー内のキーワードのネスト](#イベントキー内のキーワードのネスト)
+  - [非推奨の特殊キーワード](#非推奨の特殊キーワード)
     - [regexesとallowlistキーワード](#regexesとallowlistキーワード)
-  - [非推奨の集計条件countルール](#非推奨の集計条件countルール)
+  - [非推奨の集計条件（'count'ルール）](#非推奨の集計条件countルール)
     - [基本事項](#基本事項)
     - [countの4パターン](#countの4パターン)
     - [パターン1の例](#パターン1の例)
@@ -135,7 +136,7 @@ falsepositives:
     - unknown
 tags:
     - t1070.006
-    - attack.defense_evasion
+    - attack.defense-evasion
 references:
     - https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon
     - https://attack.mitre.org/techniques/T1070/006/
@@ -208,17 +209,17 @@ sample-evtx: |
 - **falsepositives [必須]**: 誤検知の可能性について記載を行います。例: `system administrator`, `normal user usage`, `normal system usage`, `legacy application`, `security team`, `none`。 不明な場合は `unknown` と記述してください。
 - **tags** [オプション]: [LOLBINS/LOLBAS](https://lolbas-project.github.io/)という手法を利用している場合、`lolbas` タグを追加してください。アラートを[MITRE ATT&CK](https://attack.mitre.org/) フレームワークにマッピングできる場合は、以下のリストから該当するものを追加してください。戦術ID（例：`attack.t1098`）を指定することも可能です。
   - `attack.reconnaissance` -> Reconnaissance (Recon)
-  - `attack.resource_development` -> Resource Development  (ResDev)
-  - `attack.initial_access` -> Initial Access (InitAccess)
+  - `attack.resource-development` -> Resource Development  (ResDev)
+  - `attack.initial-access` -> Initial Access (InitAccess)
   - `attack.execution` -> Execution (Exec)
   - `attack.persistence` -> Persistence (Persis)
-  - `attack.privilege_escalation` -> Privilege Escalation (PrivEsc)
-  - `attack.defense_evasion` -> Defense Evasion (Evas)
-  - `attack.credential_access` -> Credential Access (CredAccess)
+  - `attack.privilege-escalation` -> Privilege Escalation (PrivEsc)
+  - `attack.defense-evasion` -> Defense Evasion (Evas)
+  - `attack.credential-access` -> Credential Access (CredAccess)
   - `attack.discovery` -> Discovery (Disc)
-  - `attack.lateral_movement` -> Lateral Movement (LatMov)
+  - `attack.lateral-movement` -> Lateral Movement (LatMov)
   - `attack.collection` -> Collection (Collect)
-  - `attack.command_and_control` -> Command and Control (C2)
+  - `attack.command-and-control` -> Command and Control (C2)
   - `attack.exfiltration` -> Exfiltration (Exfil)
   - `attack.impact` -> Impact (Impact)
 - **references** [オプション]: 参考文献への任意のリンク。

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ falsepositives:
     - unknown
 tags:
     - t1070.006
-    - attack.defense_evasion
+    - attack.defense-evasion
 references:
     - https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon
     - https://attack.mitre.org/techniques/T1070/006/
@@ -207,17 +207,17 @@ sample-evtx: |
 - **falsepositives [required]**: The possibilities for false positives. For example: `system administrator`, `normal user usage`, `normal system usage`, `legacy application`, `security team`, `none`. If it is unknown, please write `unknown`.
 - **tags** [optional]: If the technique is a [LOLBINS/LOLBAS](https://lolbas-project.github.io/) technique, please add the `lolbas` tag. If the alert can be mapped to a technique in the [MITRE ATT&CK](https://attack.mitre.org/) framework, please add the tactic ID (Example: `attack.t1098`) and any applicable tactics below:
   - `attack.reconnaissance` -> Reconnaissance (Recon)
-  - `attack.resource_development` -> Resource Development  (ResDev)
-  - `attack.initial_access` -> Initial Access (InitAccess)
+  - `attack.resource-development` -> Resource Development  (ResDev)
+  - `attack.initial-access` -> Initial Access (InitAccess)
   - `attack.execution` -> Execution (Exec)
   - `attack.persistence` -> Persistence (Persis)
-  - `attack.privilege_escalation` -> Privilege Escalation (PrivEsc)
-  - `attack.defense_evasion` -> Defense Evasion (Evas)
-  - `attack.credential_access` -> Credential Access (CredAccess)
+  - `attack.privilege-escalation` -> Privilege Escalation (PrivEsc)
+  - `attack.defense-evasion` -> Defense Evasion (Evas)
+  - `attack.credential-access` -> Credential Access (CredAccess)
   - `attack.discovery` -> Discovery (Disc)
-  - `attack.lateral_movement` -> Lateral Movement (LatMov)
+  - `attack.lateral-movement` -> Lateral Movement (LatMov)
   - `attack.collection` -> Collection (Collect)
-  - `attack.command_and_control` -> Command and Control (C2)
+  - `attack.command-and-control` -> Command and Control (C2)
   - `attack.exfiltration` -> Exfiltration (Exfil)
   - `attack.impact` -> Impact (Impact)
 - **references** [optional]: Any links to references.

--- a/hayabusa/builtin/BitsClient_Op/BitsCli_59_Info_BitsJobCreated.yml
+++ b/hayabusa/builtin/BitsClient_Op/BitsCli_59_Info_BitsJobCreated.yml
@@ -1,6 +1,6 @@
 author: 'Zach Mathis'
 date: 2020/11/08
-modified: 2022/06/21
+modified: 2025/02/10
 
 title: 'Bits Job Created'
 details: 'JobTitle: %JobTitle% ¦ URL: %Url%'
@@ -20,7 +20,7 @@ detection:
 falsepositives:
     - normal system usage
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.persistence
     - attack.t1197
     - lolbas

--- a/hayabusa/builtin/PowerShellClassic/PwShClassic_400_Med_PwShStarted_V2DowngradeAttack.yml
+++ b/hayabusa/builtin/PowerShellClassic/PwShClassic_400_Med_PwShStarted_V2DowngradeAttack.yml
@@ -1,6 +1,6 @@
 author: Yusuke Matsui, Zach Mathis
 date: 2020/11/08
-modified: 2022/11/14
+modified: 2025/02/10
 
 title: PwSh 2.0 Downgrade Attack
 details: 'Data: %Data[3]%' # %Data[1]% is the new engine state. %Data[2]% is the previous engine state. This info is also in %Data[3]% so is unneeded.
@@ -21,7 +21,7 @@ detection:
 falsepositives:
     - legacy applications
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1562.010
     - lolbas
 references:

--- a/hayabusa/builtin/Security/AccountLogon/KerberosAuthenticationService/Sec_4768_Med_KrbTGT-Req_PossibleAS-REP-Roasting.yml
+++ b/hayabusa/builtin/Security/AccountLogon/KerberosAuthenticationService/Sec_4768_Med_KrbTGT-Req_PossibleAS-REP-Roasting.yml
@@ -1,6 +1,6 @@
 author: Yusuke Matsui, Zach Mathis
 date: 2020/11/08
-modified: 2022/12/16
+modified: 2025/02/10
 
 title: 'Possible AS-REP Roasting (RC4 Kerberos Ticket Req)'
 description: 'For each account found without preauthentication, an adversary may send an AS-REQ message without the encrypted timestamp and receive an AS-REP message with TGT data which may be encrypted with an insecure algorithm such as RC4.'
@@ -21,7 +21,7 @@ detection:
 falsepositives:
     - legacy application
 tags:
-    - attack.credential_access
+    - attack.credential-access
     - attack.t1558.004
 references:
     - https://attack.mitre.org/techniques/T1558/004/

--- a/hayabusa/builtin/Security/AccountLogon/KerberosAuthenticationService/Sec_4769_Med_KerberosTGT-Request_PossibleKerberoasting.yml
+++ b/hayabusa/builtin/Security/AccountLogon/KerberosAuthenticationService/Sec_4769_Med_KerberosTGT-Request_PossibleKerberoasting.yml
@@ -1,6 +1,6 @@
 author: Yusuke Matsui, Zach Mathis
 date: 2020/11/08
-modified: 2022/12/16
+modified: 2025/02/10
 
 title: 'Possible Kerberoasting (RC4 Kerberos Ticket Req)'
 description: 'Adversaries may abuse a valid Kerberos ticket-granting ticket (TGT) or sniff network traffic to obtain a ticket-granting service (TGS) ticket that may be vulnerable to Brute Force.'
@@ -20,7 +20,7 @@ detection:
 falsepositives:
     - legacy application
 tags:
-    - attack.credential_access
+    - attack.credential-access
     - attack.t1558.003
 references:
     - https://attack.mitre.org/techniques/T1558/003/

--- a/hayabusa/builtin/Security/AccountManagement/UserAccountManagement/Sec_4723_Med_AcctPassword_OwnChanged.yml
+++ b/hayabusa/builtin/Security/AccountManagement/UserAccountManagement/Sec_4723_Med_AcctPassword_OwnChanged.yml
@@ -1,6 +1,6 @@
 author: Darkrael
 date: 2025/01/13
-modified: 2025/01/27
+modified: 2025/02/10
 
 title: User Password Changed
 description: A user account changed it's own password. Adversaries might change the password to lockout legitimate user or set the password to a known clear text passwort via Pass the Hash if only the password hash is known. This will allow an adversary to access services where Pass the Hash is not an option.
@@ -21,7 +21,7 @@ detection:
 falsepositives:
     - none
 tags:
-    - attack.privilege_escalation
+    - attack.privilege-escalation
 references: 
     - https://trustedsec.com/blog/manipulating-user-passwords-without-mimikatz
 ruletype: Hayabusa

--- a/hayabusa/builtin/Security/AccountManagement/UserAccountManagement/Sec_4724_Med_AcctPassword_OtherChanged.yml
+++ b/hayabusa/builtin/Security/AccountManagement/UserAccountManagement/Sec_4724_Med_AcctPassword_OtherChanged.yml
@@ -1,6 +1,6 @@
 author: Darkrael
 date: 2025/01/13
-modified: 2025/01/27
+modified: 2025/02/10
 
 title: Password Reset By Admin
 description: A user accounts password was changed by another account. The current password is not required to reset the password. An adversary might change the password of another account to lock out legitimate users or gain access to the account. This could be done if the account controlled by the attacker has permission to change the password, or as a step in attacks like Pass the Cert.
@@ -21,7 +21,7 @@ detection:
 falsepositives:
     - none
 tags:
-    - attack.privilege_escalation
+    - attack.privilege-escalation
 references:
     - https://offsec.almond.consulting/authenticating-with-certificates-when-pkinit-is-not-supported.html
 ruletype: Hayabusa

--- a/hayabusa/builtin/Security/Default/Sec_1102_High_SecLogCleared.yml
+++ b/hayabusa/builtin/Security/Default/Sec_1102_High_SecLogCleared.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2020/11/08
-modified: 2022/12/16
+modified: 2025/02/10
 
 title: 'Log Cleared'
 description: 'A user has cleared the Security event log.'
@@ -19,7 +19,7 @@ detection:
 falsepositives:
     - system administrator
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1070.001
 references:
     - https://attack.mitre.org/techniques/T1070/001/

--- a/hayabusa/builtin/Security/Default/Sec_5397_Low_CredentialManagerAccessed.yml
+++ b/hayabusa/builtin/Security/Default/Sec_5397_Low_CredentialManagerAccessed.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2023/01/11
-modified: 2023/01/11
+modified: 2025/02/10
 
 title: 'Credential Manager Accessed'
 description: 'A process has read credentials in the Credential Manager. There will be many false positives so check if the Process ID (PID) is that of known malware on the system.'
@@ -24,7 +24,7 @@ detection:
 falsepositives:
     - 'High. This event will often happen legitimately.'
 tags:
-    - attack.credential_access
+    - attack.credential-access
     - attack.t1555.004
 references:
     - https://www.techradar.com/news/what-is-windows-credential-manager

--- a/hayabusa/builtin/Security/Default/Sec_5397_Low_CredentialManagerEnumerated.yml
+++ b/hayabusa/builtin/Security/Default/Sec_5397_Low_CredentialManagerEnumerated.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2023/01/11
-modified: 2023/01/11
+modified: 2025/02/10
 
 title: 'Credential Manager Enumerated'
 description: 'A process has enumerated credential information in Credential Manager. There will be many false positives so check if the Process ID (PID) is that of known malware on the system.'
@@ -24,7 +24,7 @@ detection:
 falsepositives:
     - 'High. This event will often happen legitimately.'
 tags:
-    - attack.credential_access
+    - attack.credential-access
     - attack.t1555.004
 references:
     - https://www.techradar.com/news/what-is-windows-credential-manager

--- a/hayabusa/builtin/Security/DetailedTracking/ProcessCreation/Sec_4688_Med_ProcExec_RDP-Hijacking.yml
+++ b/hayabusa/builtin/Security/DetailedTracking/ProcessCreation/Sec_4688_Med_ProcExec_RDP-Hijacking.yml
@@ -21,7 +21,7 @@ detection:
 falsepositives:
   - Unknown
 tags:
-  - attack.lateral_movement
+  - attack.lateral-movement
   - attack.t1563.002
   - attack.t1021.001
 references:

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_UserGuessing_Cnt_Deprecated.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_UserGuessing_Cnt_Deprecated.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2021/12/20
-modified: 2022/05/21
+modified: 2025/02/10
 
 title: User Guessing
 details: ''  #Cannot be used because this is a count rule
@@ -23,7 +23,7 @@ detection:
 falsepositives:
 tags:
     - attack.t1110.003
-    - attack.credential_access
+    - attack.credential-access
 references: https://attack.mitre.org/techniques/T1110/003/
 ruletype: Hayabusa
 

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_UserGuessing_Correlation.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_UserGuessing_Correlation.yml
@@ -11,7 +11,7 @@ date: 2024-10-13
 modified: 2024-10-13
 tags:
     - attack.t1110.003
-    - attack.credential_access
+    - attack.credential-access
 correlation:
     generate: true
     type: value_count

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_WrongPW_PW-Guessing_Cnt_Deprecated.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_WrongPW_PW-Guessing_Cnt_Deprecated.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2021/12/20
-modified: 2022/05/21
+modified: 2025/02/10
 
 title: PW Guessing
 description: Search for many 4625 wrong password failed logon attempts in a short period of time.
@@ -24,7 +24,7 @@ falsepositives:
     - User mistyping password
 tags:
     - attack.t1110.003
-    - attack.credential_access
+    - attack.credential-access
 references: https://attack.mitre.org/techniques/T1110/003/
 ruletype: Hayabusa
 

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_WrongPW_PW-Guessing_Correlation.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4625_Med_LogonFail_WrongPW_PW-Guessing_Correlation.yml
@@ -8,10 +8,10 @@ description: Detects password guessing attacks
 references: https://attack.mitre.org/techniques/T1110/003/
 author: Zach Mathis
 date: 2024-10-13
-modified: 2024-10-13
+modified: 2025-02-10
 tags:
     - attack.t1110.003
-    - attack.credential_access
+    - attack.credential-access
 correlation:
     type: event_count
     rules:

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Info_ExplicitLogon.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Info_ExplicitLogon.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2021/12/17
-modified: 2023/06/08
+modified: 2025/02/10
 
 title: Explicit Logon
 description: |
@@ -37,8 +37,8 @@ detection:
 falsepositives:
     - normal system usage
 tags:
-    - attack.privilege_escalation
-    - attack.lateral_movement
+    - attack.privilege-escalation
+    - attack.lateral-movement
 references:
     - https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4648
 ruletype: Hayabusa

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Info_ExplicitLogon_Noisy.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Info_ExplicitLogon_Noisy.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2023/06/08
-modified: 2023/06/08
+modified: 2025/02/10
 
 title: Explicit Logon (Noisy)
 description: |
@@ -37,8 +37,8 @@ detection:
 falsepositives:
     - normal system usage
 tags:
-    - attack.privilege_escalation
-    - attack.lateral_movement
+    - attack.privilege-escalation
+    - attack.lateral-movement
 references:
     - https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4648
 ruletype: Hayabusa

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_PW-Spray_Cnt_Deprecated.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_PW-Spray_Cnt_Deprecated.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2021/12/20
-modified: 2022/03/22
+modified: 2025/02/10
 
 title: PW Spray
 details: ''  #Cannot be used because this is a count rule
@@ -23,7 +23,7 @@ detection:
 falsepositives:
 tags:
     - attack.t1110.003
-    - attack.credential_access
+    - attack.credential-access
 references: https://attack.mitre.org/techniques/T1110/003/
 sample-evtx: ./hayabusa-sample-evtx/DeepBlueCLI/password-spray.evtx
 ruletype: Hayabusa

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_PW-Spray_Correlation.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_PW-Spray_Correlation.yml
@@ -7,11 +7,11 @@ status: test
 description: Search for many 4648 explicit credential logon attempts in a short period of time.
 references: https://attack.mitre.org/techniques/T1110/003/
 author: Zach Mathis
-date: 2024-10-19
-modified: 2024-10-19
+date: 2024/10/19
+modified: 2024/10/19
 tags:
     - attack.t1110.003
-    - attack.credential_access
+    - attack.credential-access
 correlation:
     type: value_count
     rules:
@@ -39,8 +39,8 @@ status: test
 description: Detects a failed logon event due to a wrong password
 references:
 author: Zach Mathis
-date: 2024-10-19
-modified: 2024-10-19
+date: 2024/10/19
+modified: 2025/02/10
 tags:
 logsource:
     product: windows

--- a/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_SuspProc.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/Logon/Sec_4648_Med_ExplicitLogon_SuspProc.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2021/12/17
-modified: 2022/12/22
+modified: 2025/02/10
 
 title: 'Explicit Logon (Suspicious Process)'
 description: Alter on explicit credential logons with suspicous processes like powershell and wmic which are often abused by malware like Cobalt Strike.
@@ -35,8 +35,8 @@ detection:
 falsepositives:
     - normal system usage
 tags:
-    - attack.privilege_escalation
-    - attack.lateral_movement
+    - attack.privilege-escalation
+    - attack.lateral-movement
 references:
     - https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4648
 sample-evtx: ./EVTX-ATTACK-SAMPLES/Privilege Escalation/Runas_4624_4648_Webshell_CreateProcessAsUserA.evtx

--- a/hayabusa/builtin/Security/LogonLogoff/OtherLogonLogoffEvents/Sec_4778_Info_RDP-SessReconn.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/OtherLogonLogoffEvents/Sec_4778_Info_RDP-SessReconn.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/29
-modified: 2023/01/11
+modified: 2025/02/10
 
 title: RDP Session Reconnect
 description: 'Detects when there is a RDP session reconnect.'
@@ -20,7 +20,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
 ruletype: Hayabusa
 

--- a/hayabusa/builtin/Security/LogonLogoff/OtherLogonLogoffEvents/Sec_4779_Info_RDP-SessDisconn.yml
+++ b/hayabusa/builtin/Security/LogonLogoff/OtherLogonLogoffEvents/Sec_4779_Info_RDP-SessDisconn.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/29
-modified: 2023/01/11
+modified: 2025/02/10
 
 title: RDP Session Disconnect
 description: 'Detects when there is a RDP session disconnect.'
@@ -20,7 +20,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
 ruletype: Hayabusa
 

--- a/hayabusa/builtin/Security/PrivilegeUse/Sec_4673_Med_PrivSvcCalled_UnknownProcUsedHighPriv.yml
+++ b/hayabusa/builtin/Security/PrivilegeUse/Sec_4673_Med_PrivSvcCalled_UnknownProcUsedHighPriv.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2020/11/08
-modified: 2022/12/16
+modified: 2025/02/10
 
 title: 'Process Ran With High Privilege'
 description: |
@@ -40,7 +40,7 @@ detection:
 falsepositives:
     - normal system usage
 tags:
-    - attack.credential_access
+    - attack.credential-access
     - attack.t1003.001
     - attack.t1561
     - attack.impact

--- a/hayabusa/builtin/Security/System/SystemIntegrity/Sec_5038_Low_CodeIntegrityErr_InvalidImgHash.yml
+++ b/hayabusa/builtin/Security/System/SystemIntegrity/Sec_5038_Low_CodeIntegrityErr_InvalidImgHash.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/05
-modified: 2022/10/14
+modified: 2025/02/10
 
 title: Code Integrity Error (Invalid Image Hash)
 details: 'Path: %param1%'
@@ -22,7 +22,7 @@ falsepositives:
     - most likely not malicious
     - disk device error
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
 references:
     - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-5038
 sample-evtx: 

--- a/hayabusa/builtin/Security/System/SystemIntegrity/Sec_6281_Low_CodeIntegrityErr_InvalidImgPageHash.yml
+++ b/hayabusa/builtin/Security/System/SystemIntegrity/Sec_6281_Low_CodeIntegrityErr_InvalidImgPageHash.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/05
-modified: 2022/10/14
+modified: 2022/02/10
 
 title: Code Integrity Error (Invalid Image Page Hash)
 details: 'Path: %param1%'
@@ -22,7 +22,7 @@ falsepositives:
     - most likely not malicious
     - disk device error
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
 references:
     - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-6281
 sample-evtx: 

--- a/hayabusa/builtin/Security/System/SystemIntegrity/Sec_6410_Low_CodeIntegrityErr_RequirementsNotMet.yml
+++ b/hayabusa/builtin/Security/System/SystemIntegrity/Sec_6410_Low_CodeIntegrityErr_RequirementsNotMet.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/05
-modified: 2022/10/14
+modified: 2025/02/10
 
 title: Code Integrity Proble (Possible Modification)
 details: 'Path: %param1%'
@@ -22,7 +22,7 @@ falsepositives:
     - most likely not malicious
     - disk device error
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
 references:
     - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-6410
 sample-evtx: 

--- a/hayabusa/builtin/System/Sys_104_High_ImportantLogCleared.yml
+++ b/hayabusa/builtin/System/Sys_104_High_ImportantLogCleared.yml
@@ -1,6 +1,6 @@
 author: Florian Roth (Nextron Systems), Tim Shelton, Zach Mathis
 date: 2020/11/08
-modified: 2023/02/23
+modified: 2025/02/10
 
 title: 'Important Log File Cleared'
 details: 'Log: %LogFileClearedChannel% ¦ User: %LogFileClearedSubjectUserName%'
@@ -36,7 +36,7 @@ falsepositives:
     - Rollout of log collection agents (the setup routine often includes a reset of the local Eventlog)
     - System provisioning (system reset before the golden image creation)
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1070.001
 references:
     - https://attack.mitre.org/techniques/T1070/001/

--- a/hayabusa/builtin/System/Sys_104_Med_LogCleared.yml
+++ b/hayabusa/builtin/System/Sys_104_Med_LogCleared.yml
@@ -1,6 +1,6 @@
 author: Florian Roth (Nextron Systems), Zach Mathis
 date: 2020/11/08
-modified: 2023/02/23
+modified: 2025/02/10
 
 title: 'Log File Cleared'
 details: 'Log: %LogFileClearedChannel% ¦ User: %LogFileClearedSubjectUserName%'
@@ -37,7 +37,7 @@ falsepositives:
     - Rollout of log collection agents (the setup routine often includes a reset of the local Eventlog)
     - System provisioning (system reset before the golden image creation)
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1070.001
 references:
     - https://attack.mitre.org/techniques/T1070/001/

--- a/hayabusa/builtin/System/Sys_7040_Med_EventLogServiceStartupDisabled.yml
+++ b/hayabusa/builtin/System/Sys_7040_Med_EventLogServiceStartupDisabled.yml
@@ -1,6 +1,6 @@
 author: Eric Conrad, Zach Mathis
 date: 2020/11/08
-modified: 2022/06/21
+modified: 2025/02/10
 
 title: Event Log Service Startup Type Changed To Disabled
 details: 'OldSetting: %param2% ¦ NewSetting: %param3%'
@@ -22,7 +22,7 @@ detection:
 falsepositives:
     - system administrator
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1562.002
 references:
     - https://attack.mitre.org/techniques/T1562/002/

--- a/hayabusa/builtin/System/Sys_7045_Med_LateralMovement-PSEXEC.yml
+++ b/hayabusa/builtin/System/Sys_7045_Med_LateralMovement-PSEXEC.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/02/06
-modified: 2022/05/21
+modified: 2025/02/10
 
 title: PSExec Lateral Movement
 details: 'Svc: %ServiceName% ¦ Path: %ImagePath% ¦ Acct: %AccountName% ¦ StartType: %StartType%'
@@ -24,7 +24,7 @@ detection:
 falsepositives:
     - systems admin
 tags:
-    - attack.lateral_movement
+    - attack.lateral-movement
     - attack.s0029
     - attack.t1136.002
     - attack.t1543.003

--- a/hayabusa/builtin/TerminalServices-Gateway_Op/RDS_Gateway_302_Info_LogonSuccess.yml
+++ b/hayabusa/builtin/TerminalServices-Gateway_Op/RDS_Gateway_302_Info_LogonSuccess.yml
@@ -1,6 +1,6 @@
 author: Jordan Lloyd
 date: 2024/08/28
-modified: 2024/11/05
+modified: 2025/02/10
 
 title: RDS GTW Logon
 details: 'TgtUser: %RdsGtwUsername% ¦ Resource: %RdsGtwResource% ¦ SrcIP: %RdsGtwIpAddress% ¦ Proto: %RdsGtwConnectionProtocol% ¦ AuthType: %RdsGtwAuthType%'
@@ -21,8 +21,8 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
-    - attack.initial_access
+    - attack.lateral-movement
+    - attack.initial-access
 references:
 ruletype: Hayabusa
 

--- a/hayabusa/builtin/TerminalServices-Gateway_Op/RDS_Gateway_302_Low_LogonError.yml
+++ b/hayabusa/builtin/TerminalServices-Gateway_Op/RDS_Gateway_302_Low_LogonError.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2024/11/05
-modified: 2024/11/05
+modified: 2025/02/10
 
 title: RDS GTW Logon Error
 details: 'TgtUser: %RdsGtwUsername% ¦ Resource: %RdsGtwResource% ¦ SrcIP: %RdsGtwIpAddress% ¦ Proto: %RdsGtwConnectionProtocol% ¦ AuthType: %RdsGtwAuthType% ¦ ErrorCode: %RdsGtwErrorCode%'
@@ -22,8 +22,8 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
-    - attack.initial_access
+    - attack.lateral-movement
+    - attack.initial-access
 references:
 ruletype: Hayabusa
 

--- a/hayabusa/builtin/TerminalServices-Gateway_Op/RDS_Gateway_303_Info_Logoff.yml
+++ b/hayabusa/builtin/TerminalServices-Gateway_Op/RDS_Gateway_303_Info_Logoff.yml
@@ -1,6 +1,6 @@
 author: Jordan Lloyd
 date: 2024/08/28
-modified: 2024/11/05
+modified: 2025/02/10
 
 title: RDS GTW Logoff
 details: 'TgtUser: %RdsGtwUsername% ¦ Resource: %RdsGtwResource% ¦ SrcIP: %RdsGtwIpAddress% ¦ Proto: %RdsGtwConnectionProtocol% ¦ AuthType: %RdsGtwAuthType% ¦ ErrorCode: %RdsGtwErrorCode% ¦ BytesReceived: %RdsGtwBytesReceived% ¦ BytesTransfered: %RdsGtwBytesTransfered% ¦ SessionDuration: %RdsGtwSessionDuration%'
@@ -20,8 +20,8 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
-    - attack.initial_access
+    - attack.lateral-movement
+    - attack.initial-access
 references:
 ruletype: Hayabusa
 

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_21_Info_RDP-Logon.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_21_Info_RDP-Logon.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/12/07
-modified: 2024/11/10
+modified: 2025/02/10
 
 title: RDP Logon
 details: 'TgtUser: %UserDataUser% ¦ SessID: %UserDataSessionID% ¦ SrcIP: %UserDataAddress%'
@@ -28,7 +28,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
     - https://www.cybertriage.com/artifact/terminalservices_localsessionmanager_log/terminalservices_localsessionmanager_operational_21/
     - https://ponderthebits.com/2018/02/windows-rdp-related-event-logs-identification-tracking-and-investigation/

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_22_Info_RDP-SessStart_Noisy.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_22_Info_RDP-SessStart_Noisy.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/12/07
-modified: 2024/11/10
+modified: 2025/02/10
 
 title: 'RDP Sess Start (Noisy)'
 details: 'TgtUser: %UserDataUser% ¦ SessID: %UserDataSessionID% ¦ SrcIP: %UserDataAddress%'
@@ -29,7 +29,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
     - https://www.cybertriage.com/artifact/terminalservices_localsessionmanager_log/terminalservices_localsessionmanager_operational_22/
     - https://ponderthebits.com/2018/02/windows-rdp-related-event-logs-identification-tracking-and-investigation/

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_23_Info_RDP-Logoff.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_23_Info_RDP-Logoff.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/12/07
-modified: 2024/11/10
+modified: 2025/02/10
 
 title: RDP Logoff
 details: 'TgtUser: %UserDataUser% ¦ SessID: %UserDataSessionID%'
@@ -20,7 +20,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
     - https://www.cybertriage.com/artifact/terminalservices_localsessionmanager_log/terminalservices_localsessionmanager_operational_23/
     - https://ponderthebits.com/2018/02/windows-rdp-related-event-logs-identification-tracking-and-investigation/

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_24_Info_RDP-Disconnect.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_24_Info_RDP-Disconnect.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/12/07
-modified: 2024/11/10
+modified: 2025/02/10
 
 title: RDP Disconnect
 details: 'TgtUser: %UserDataUser% ¦ SessID: %UserDataSessionID% ¦ SrcIP: %UserDataAddress%'
@@ -23,7 +23,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
     - https://www.cybertriage.com/artifact/terminalservices_localsessionmanager_log/terminalservices_localsessionmanager_operational_24/
     - https://ponderthebits.com/2018/02/windows-rdp-related-event-logs-identification-tracking-and-investigation/

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_25_Info_RDP-Reconnect.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_25_Info_RDP-Reconnect.yml
@@ -1,6 +1,6 @@
 author: Fukusuke Takahashi
 date: 2024/11/03
-modified: 2024/11/10
+modified: 2025/02/10
 
 title: RDP Reconnect
 details: "TgtUser: %UserDataUser% ¦ SessID: %UserDataSessionID% ¦ SrcIP: %UserDataAddress%"
@@ -21,7 +21,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 ruletype: Hayabusa
 
 sample-message: |

--- a/hayabusa/builtin/TerminalServices-RDPClient_Op/RDP-Client_1024_Info_ConnAttempt.yml
+++ b/hayabusa/builtin/TerminalServices-RDPClient_Op/RDP-Client_1024_Info_ConnAttempt.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/28
-modified: 2023/07/05
+modified: 2025/02/10
 
 title: RDP Conn Attempt
 details: 'TgtIP: %Value%'
@@ -20,7 +20,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
 ruletype: Hayabusa
 

--- a/hayabusa/builtin/TerminalServices-RDPClient_Op/RDP-Client_1102_Info_ConnAttempt.yml
+++ b/hayabusa/builtin/TerminalServices-RDPClient_Op/RDP-Client_1102_Info_ConnAttempt.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/29
-modified: 2022/03/29
+modified: 2025/02/10
 
 title: RDP Attempt
 details: 'TgtIP: %Value%'
@@ -20,7 +20,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
 ruletype: Hayabusa
 

--- a/hayabusa/builtin/TerminalServices-RemoteConnectionManager_Op/RemoteConnManger_1149_Info_RDP-LogonAttempt.yml
+++ b/hayabusa/builtin/TerminalServices-RemoteConnectionManager_Op/RemoteConnManger_1149_Info_RDP-LogonAttempt.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/12/07
-modified: 2024/11/10
+modified: 2025/02/10
 
 title: RDP Logon
 details: 'TgtUser: %UserDataParam1% ¦ Domain: %UserDataParam2% ¦ SrcIP: %UserDataParam3%'
@@ -27,8 +27,8 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
-    - attack.initial_access
+    - attack.lateral-movement
+    - attack.initial-access
 references:
     - https://www.cybertriage.com/artifact/terminalservices_remoteconnectionmanager_log/terminalservices_remoteconnectionmanager_operational_1149/
     - https://ponderthebits.com/2018/02/windows-rdp-related-event-logs-identification-tracking-and-investigation/

--- a/hayabusa/builtin/TerminalServices-RemoteConnectionManager_Op/RemoteConnManger_261_Info_RDP-Conn_Noisy.yml
+++ b/hayabusa/builtin/TerminalServices-RemoteConnectionManager_Op/RemoteConnManger_261_Info_RDP-Conn_Noisy.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/12/07
-modified: 2024/11/10
+modified: 2025/02/10
 
 title: 'RDP Conn (Noisy)'
 details: ''
@@ -25,7 +25,7 @@ falsepositives:
     - administrator
 tags:
     - RDP
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
     - https://www.cybertriage.com/artifact/terminalservices_remoteconnectionmanager_log/terminalservices_remoteconnectionmanager_operational_261/
 ruletype: Hayabusa

--- a/hayabusa/builtin/WMI-Activity_Op/WMI_5861_Med_FilterToConsumerBinding_CmdExec.yml
+++ b/hayabusa/builtin/WMI-Activity_Op/WMI_5861_Med_FilterToConsumerBinding_CmdExec.yml
@@ -1,6 +1,6 @@
 author: 'Zach Mathis'
 date: 2022/04/06
-modified: 2023/02/27
+modified: 2025/02/10
 
 title: 'WMI Filter To Consumer Binding_Command Execution'
 details: 'Namespace: %UserDataNamespace% ¦ Consumer: %UserDataConsumer% ¦ Details: %UserDataPossibleCause%'
@@ -29,7 +29,7 @@ falsepositives:
 tags:
     - WMI
     - attack.persistence
-    - attack.lateral_movement
+    - attack.lateral-movement
 references:
     - https://attack.mitre.org/techniques/T1546/003/
     - https://www.varonis.com/blog/wmi-windows-management-instrumentation

--- a/hayabusa/sysmon/Sysmon_1_High_ProcExec_NonExeProcExec.yml
+++ b/hayabusa/sysmon/Sysmon_1_High_ProcExec_NonExeProcExec.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/02/05
-modified: 2023/01/13
+modified: 2025/02/10
 
 title: Proc Exec (Non-Exe Filetype)
 description: Checks whether the image specified in a process creation event doesn't refer to an .exe file.
@@ -25,7 +25,7 @@ detection:
 falsepositives:
     - 'normal system usage'
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - sysmon
 references:
     - Based on a sigma rule by Max Altgelt but re-written due to many false positives and potential for false negatives.

--- a/hayabusa/sysmon/Sysmon_27_High_BlockedExeFileCreation.yml
+++ b/hayabusa/sysmon/Sysmon_27_High_BlockedExeFileCreation.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/09/01
-modified: 2023/01/13
+modified: 2025/02/10
 
 title: 'Blocked Exe File Creation'
 description: 'Sysmon blocked an .exe file from being written to disk based on various suspicious conditions.'
@@ -20,7 +20,7 @@ detection:
 falsepositives:
 tags:
     - sysmon
-    - attack.defense_evasion
+    - attack.defense-evasion
 references:
     - https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon
     - https://medium.com/@olafhartong/sysmon-14-0-fileblockexecutable-13d7ba3dff3e

--- a/hayabusa/sysmon/Sysmon_2_Low_PossibleTimestomping.yml
+++ b/hayabusa/sysmon/Sysmon_2_Low_PossibleTimestomping.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/22
-modified: 2023/01/13
+modified: 2025/02/10
 
 title: 'Possible Timestomping'
 details: 'Path: %TargetFilename% ¦ Proc: %Image% ¦ User: %User% ¦ CreateTime: %CreationUtcTime% ¦ PrevTime: %PreviousCreationUtcTime% ¦ PID: %PID% ¦ PGUID: %ProcessGuid%'
@@ -26,7 +26,7 @@ falsepositives:
     - unknown
 tags:
     - t1070.006
-    - attack.defense_evasion
+    - attack.defense-evasion
     - sysmon
 references:
     - https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon

--- a/hayabusa/sysmon/Sysmon_6_DrvLoaded_SuspPath.yml
+++ b/hayabusa/sysmon/Sysmon_6_DrvLoaded_SuspPath.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/05
-modified: 2023/01/13
+modified: 2025/02/10
 
 title: 'Driver Loaded (Suspicious Path)'
 description: 
@@ -24,7 +24,7 @@ detection:
     condition: selection and not filter
 falsepositives:
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1553.002
     - sysmon
 references:

--- a/hayabusa/sysmon/Sysmon_6_High_DrvLoaded_InvalidSig.yml
+++ b/hayabusa/sysmon/Sysmon_6_High_DrvLoaded_InvalidSig.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/05
-modified: 2023/01/13
+modified: 2023/02/10
 
 title: 'Driver Loaded (Invalid Signature)'
 description: 'Loaded driver was signed with an invalid signature.'
@@ -22,7 +22,7 @@ detection:
     condition: selection and not filter
 falsepositives:
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1553.002
     - sysmon
 references:

--- a/hayabusa/sysmon/Sysmon_6_Low_DrvLoaded_UnkwnSig_Noisy.yml
+++ b/hayabusa/sysmon/Sysmon_6_Low_DrvLoaded_UnkwnSig_Noisy.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/05
-modified: 2023/01/13
+modified: 2025/02/10
 
 title: 'Driver Loaded (Unknown Signature) (Noisy)'
 description: 'This rule is marked as noisy by default due to a high probability of false positives.'
@@ -32,7 +32,7 @@ detection:
     condition: selection and not filter
 falsepositives:
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1553.002
     - sysmon
 references:

--- a/hayabusa/sysmon/Sysmon_6_Med_DrvLoaded_ExpiredOrRevoked.yml
+++ b/hayabusa/sysmon/Sysmon_6_Med_DrvLoaded_ExpiredOrRevoked.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/05
-modified: 2023/01/13
+modified: 2023/02/10
 
 title: 'Driver Loaded (Expired/Revoked Cert)'
 description: ''
@@ -23,7 +23,7 @@ detection:
 falsepositives:
     - 'Software with expired/revoked certs'
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1553.002
     - sysmon
 references:

--- a/hayabusa/sysmon/Sysmon_6_Med_DrvLoaded_Unsigned.yml
+++ b/hayabusa/sysmon/Sysmon_6_Med_DrvLoaded_Unsigned.yml
@@ -1,6 +1,6 @@
 author: Zach Mathis
 date: 2022/03/05
-modified: 2023/01/13
+modified: 2025/02/10
 
 title: 'Driver Loaded (Unsigned)'
 description: 
@@ -23,7 +23,7 @@ detection:
 falsepositives:
     - 'Expired/revoked certs'
 tags:
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1553.002
     - sysmon
 references:


### PR DESCRIPTION
Closes https://github.com/Yamato-Security/hayabusa-rules/issues/819

In Sigma v2, the tagging convention is to use hyphens instead of underscores so I updated the readme and hayabusa rules to use the v2 version.

@fukusuket Can you check when you get a chance?