### PR TITLE
fix: level-tuning id 

### DIFF
--- a/config/level_tuning.txt
+++ b/config/level_tuning.txt
@@ -1,5 +1,5 @@
 id,new_level
-570ae5ec-33dc-427c-b815-db86228ad43e,informational # 'Application Uninstalled' - Originally low.
+33c276a1-2475-2f1f-aa3d-ec5d61dbe94c,informational # 'Application Uninstalled' - Originally low.
 b6ce0b2f-593b-5e1c-e137-d30b2974e30e,high # 'Suspicious Double Extension File Execution' - Sysmon 1 - Originally critical
 452b2159-5e6e-c494-63b9-b385d6195f58,high # 'Suspicious Double Extension File Execution' - Security 4688 - Originally critical
 51ba8477-86a4-6ff0-35fa-7b7f1b1e3f83,high # 'CobaltStrike Service Installations - System' - System 7045 - Originally critical


### PR DESCRIPTION
I found id typo so I fixed it!
https://github.com/Yamato-Security/hayabusa-rules/blob/509246a457d8f7be687b534e48616fd62e7828f1/sigma/builtin/application/msiinstaller/win_builtin_remove_application.yml#L1-L5