### PR TITLE
feat: add System 6013 uptime/timezone rule

### DIFF
--- a/hayabusa/builtin/System/Sys_6013_Info_ComputerUpTime.yml
+++ b/hayabusa/builtin/System/Sys_6013_Info_ComputerUpTime.yml
@@ -1,0 +1,54 @@
+author: Fukusuke Takahashi
+date: 2024/03/28
+
+title: Computer Uptime/Timezone
+details: 'UpTime: %Data[5]% ¦ Timezone: %Data[7]%'
+description: |
+    This is an event that shows the computer uptime.This event is important because it also contains the OS timezone information.
+
+id: 982fdd1f-38fe-4243-bea3-6032fc01b723
+level: informational
+status: test
+logsource:
+    product: windows
+    service: system
+detection:
+    selection:
+        Channel: System
+        EventID: 6013
+    condition: selection
+falsepositives:
+tags:
+references:
+ruletype: Hayabusa
+
+sample-evtx:
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+      <System>
+        <Provider Name="EventLog" />
+        <EventID Qualifiers="32768">6013</EventID>
+        <Version>0</Version>
+        <Level>4</Level>
+        <Task>0</Task>
+        <Opcode>0</Opcode>
+        <Keywords>0x80000000000000</Keywords>
+        <TimeCreated SystemTime="2025-03-27T22:34:51.3133019Z" />
+        <EventRecordID>1796</EventRecordID>
+        <Correlation />
+        <Execution ProcessID="1908" ThreadID="2084" />
+        <Channel>System</Channel>
+        <Computer>samurai</Computer>
+        <Security />
+      </System>
+      <EventData>
+        <Data />
+        <Data />
+        <Data />
+        <Data />
+        <Data>8852</Data>
+        <Data>60</Data>
+        <Data>-540 東京 (標準時)</Data>
+        <Binary>
+          31002E003100000030000000570069006E0064006F00770073002000310030002000500072006F000000310030002E0030002E003200360031003000300020004200750069006C0064002000320036003100300030002000200000004D0075006C0074006900700072006F0063006500730073006F007200200046007200650065000000320036003100300030002E00670065005F00720065006C0065006100730065002E003200340030003300330031002D00310034003300350000003600370064003400650035003600310000004E006F007400200041007600610069006C00610062006C00650000004E006F007400200041007600610069006C00610062006C006500000031003200000032000000340030003900310000003400310031000000730061006D00750072006100690000000000</Binary>
+      </EventData>
+    </Event>


### PR DESCRIPTION
## What Changed
- Related https://github.com/Yamato-Security/takajo/issues/234
- Related https://github.com/Yamato-Security/hayabusa/issues/1638

## Evidense
```
% ./hayabusa csv-timeline -d ../data/hayabusa-sample-evtx-main -r ~/Scripts/Python/hayabusa-rules/hayabusa/builtin/System/Sys_6013_Info_ComputerUpTime.yml -w -q
Start time: 2025/03/28 07:48
Total event log files: 598
Total file size: 139.2 MB

Loading detection rules. Please wait.


Test rules: 1 (100.00%)

Expand rules: 0 (0.00%)
Enabled expand rules: 0 (0.00%)

Hayabusa rules: 1
Total detection rules: 1

Creating the channel filter. Please wait.

Evtx files loaded after channel filter: 19
Detection rules enabled after channel filter: 1

Output profile: standard

Scanning in progress. Please wait.

Timestamp · RuleTitle · Level · Computer · Channel · EventID · RecordID · Details · ExtraFieldInfo · RuleID
2013-10-24 01:21:28.000 +09:00 · Computer Uptime/Timezone · info · IE8Win7 · Sys · 6013 · 285 · UpTime: 181 ¦ Timezone: 480 Pacific Standard Time · Binary: 31002E003100000030000000570069006E0064006F007700730020003700200045006E0074006500720070007200690073006500000036002E0031002E00370036003000300020004200750069006C006400200037003600300030002000200000004D0075006C0074006900700072006F0063006500730073006F00720020004600720065006500000037003600300030002E00770069006E0037005F00720074006D002E003000390030003700310033002D00310032003500350000003500320036003700660036006300310000004E006F007400200041007600610069006C00610062006C00650000004E006F007400200041007600610069006C00610062006C0065000000300000003100000035003100320000003400300039000000490045003800570069006E00370000000000 ¦ Data[1]:  ¦ Data[2]:  ¦ Data[3]:  ¦ Data[4]:  ¦ Data[6]: 60 · 982fdd1f-38fe-4243-bea3-6032fc01b723
```

I would appreciate it if you could check it out when you have time🙏