### PR TITLE
chg: add logsource:service/category

### DIFF
--- a/hayabusa/builtin/DNS-Server/DNS-ServerAnalytical_260_Info_DNS-Request.yml
+++ b/hayabusa/builtin/DNS-Server/DNS-ServerAnalytical_260_Info_DNS-Request.yml
@@ -10,6 +10,7 @@ level: informational
 status: stable
 logsource:
     product: windows
+    service: dns-server-analytic
     description: 'Requirements: Microsoft-Windows-DNS-Server/Analytical ({EB79061A-A566-4698-9119-3ED2807060E7}) Event Log must be collected in order to receive the events.'
 detection:
     selection:

--- a/hayabusa/builtin/DNS-Server/DNS-ServerAnalytical_261_Info_DNS-Response.yml
+++ b/hayabusa/builtin/DNS-Server/DNS-ServerAnalytical_261_Info_DNS-Response.yml
@@ -10,6 +10,7 @@ level: informational
 status: experimental
 logsource:
     product: windows
+    service: dns-server-analytic
     description: 'Requirements: Microsoft-Windows-DNS-Server/Analytical ({EB79061A-A566-4698-9119-3ED2807060E7}) Event Log must be collected in order to receive the events.'
 detection:
     selection:

--- a/hayabusa/builtin/DriverFrameworks_UserMode_Op/DvrFmwk_2003_Info_USB-PluggedIn.yml
+++ b/hayabusa/builtin/DriverFrameworks_UserMode_Op/DvrFmwk_2003_Info_USB-PluggedIn.yml
@@ -11,6 +11,7 @@ level: informational
 status: experimental
 logsource:
     product: windows
+    service: driver-framework
     description: Logging needs to be turned on.
 detection:
     selection:

--- a/hayabusa/builtin/NTFS_Op/NTFS_4_info_volume_mount.yml
+++ b/hayabusa/builtin/NTFS_Op/NTFS_4_info_volume_mount.yml
@@ -11,6 +11,7 @@ level: informational
 status: test
 logsource:
   product: windows
+  service: ntfs
 detection:
   selection:
     Channel: 'Microsoft-Windows-Ntfs/Operational'

--- a/hayabusa/builtin/PowerShellClassic/PwShClassic_400_Info_PwShEngineStarted.yml
+++ b/hayabusa/builtin/PowerShellClassic/PwShClassic_400_Info_PwShEngineStarted.yml
@@ -11,7 +11,8 @@ level: informational
 status: test
 logsource:
     product: windows
-    service: powershell
+    service: powershell-classic
+    category: ps_classic_start
 detection:
     selection:
         Channel: 'Windows PowerShell'

--- a/hayabusa/builtin/PowerShellClassic/PwShClassic_400_Med_PwShStarted_V2DowngradeAttack.yml
+++ b/hayabusa/builtin/PowerShellClassic/PwShClassic_400_Med_PwShStarted_V2DowngradeAttack.yml
@@ -11,7 +11,8 @@ level: medium
 status: test
 logsource:
     product: windows
-    service: powershell
+    service: powershell-classic
+    category: ps_classic_start
 detection:
     selection:
         Channel: 'Windows PowerShell'

--- a/hayabusa/builtin/PowerShell_Op/PwSh_4103_Info_PipelineExecution.yml
+++ b/hayabusa/builtin/PowerShell_Op/PwSh_4103_Info_PipelineExecution.yml
@@ -11,6 +11,7 @@ status: stable
 logsource:
     product: windows
     service: powershell
+    category: ps_module
     description: Powershell module logging needs to be turned on.
 detection:
     select_channel:

--- a/hayabusa/builtin/PowerShell_Op/PwSh_4104_Info_ScriptblockLog.yml
+++ b/hayabusa/builtin/PowerShell_Op/PwSh_4104_Info_ScriptblockLog.yml
@@ -13,6 +13,7 @@ status: stable
 logsource:
     product: windows
     service: powershell
+    category: ps_script
     description: Powershell script block logging needs to be turned on.
 detection:
     select_channel:

--- a/hayabusa/builtin/PowerShell_Op/PwSh_4104_Med_ScriptblockLog_PotentiallyMalicious.yml
+++ b/hayabusa/builtin/PowerShell_Op/PwSh_4104_Med_ScriptblockLog_PotentiallyMalicious.yml
@@ -11,6 +11,7 @@ status: stable
 logsource:
     product: windows
     service: powershell
+    category: ps_script
     description: Default with PwSh 5+ (Ex. Win 10+)
 detection:
     select_channel:

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_21_Info_RDP-Logon.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_21_Info_RDP-Logon.yml
@@ -19,6 +19,7 @@ level: informational
 status: stable
 logsource:
     product: windows
+    service: terminalservices-localsessionmanager
 detection:
     selection:
         Channel: 'Microsoft-Windows-TerminalServices-LocalSessionManager/Operational'

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_22_Info_RDP-SessStart_Noisy.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_22_Info_RDP-SessStart_Noisy.yml
@@ -20,6 +20,7 @@ level: informational
 status: stable
 logsource:
     product: windows
+    service: terminalservices-localsessionmanager
 detection:
     selection:
         Channel: 'Microsoft-Windows-TerminalServices-LocalSessionManager/Operational'

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_23_Info_RDP-Logoff.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_23_Info_RDP-Logoff.yml
@@ -11,6 +11,7 @@ level: informational
 status: stable
 logsource:
     product: windows
+    service: terminalservices-localsessionmanager
 detection:
     selection:
         Channel: 'Microsoft-Windows-TerminalServices-LocalSessionManager/Operational'

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_24_Info_RDP-Disconnect.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_24_Info_RDP-Disconnect.yml
@@ -14,6 +14,7 @@ level: informational
 status: stable
 logsource:
     product: windows
+    service: terminalservices-localsessionmanager
 detection:
     selection:
         Channel: 'Microsoft-Windows-TerminalServices-LocalSessionManager/Operational'

--- a/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_25_Info_RDP-Reconnect.yml
+++ b/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_25_Info_RDP-Reconnect.yml
@@ -12,6 +12,7 @@ level: informational
 status: test
 logsource:
     product: windows
+    service: terminalservices-localsessionmanager
 detection:
     selection:
         Channel: "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational"


### PR DESCRIPTION
Since the following feature refers to the service and category fields, I added these fields to the Hayabusa rules where they were not explicitly declared.
- https://github.com/Yamato-Security/WELA-RulesGenerator/pull/2
  - https://fukusuket-eventlog-baseline-guide-streamlit-app-cty7uv.streamlit.app/

The Sigma specification was referenced from the following document.
- https://github.com/Yamato-Security/sigma-to-hayabusa-converter?tab=readme-ov-file#about-the-logsource-field
- https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md#logsource
- https://github.com/SigmaHQ/sigma-specification/blob/main/appendix/sigma-taxonomy-appendix.md

I’d appreciate it if you could check it when you have time🙏