### PR TITLE
Fix RDPClient channel abbreviation

### DIFF
--- a/config/channel_abbreviations.txt
+++ b/config/channel_abbreviations.txt
@@ -18,7 +18,7 @@ Microsoft-Windows-Security-Mitigations/UserMode,SecMitig
 Microsoft-Windows-SmbClient/Security,SmbCliSec
 Microsoft-Windows-Sysmon/Operational,Sysmon
 Microsoft-Windows-TaskScheduler/Operational,TaskSch
-Microsoft-Windows-TerminalServices-RDPClient/Operational,RDP-Client
+Microsoft-Windows-TerminalServices-RDPClient/Operational,RDP-Cli
 Microsoft-Windows-RemoteDesktopServices-RdpCoreTS/Operational,RDP-CoreTS
 Microsoft-Windows-PrintService/Admin,PrintAdm
 Microsoft-Windows-PrintService/Operational,PrintOp


### PR DESCRIPTION
### Summary
This pull request fixes the RDPClient channel abbreviation. It is currently set to "RDP-Client", but since the generic abbreviations file contains the abbrevation "Cli" for "Client", Hayabusa timeline actually uses "RDP-Cli" instead.

### Changes Made
- Changed abbreviation from "RDP-Client" to "RDP-Cli" at the end of line 21

### How to Test
1. Pull the branch "bugfix/fix-rdp-client-channel-abbreviation".
2. Run Hayabusa csv-timeline
3. Notice that the RDPClient channel abbrevation is "RDP-Cli" before and after this change.

### Additional Notes
- Full name of the RDPClient channel: Microsoft-Windows-TerminalServices-RDPClient/Operational
- Path of the channel abbreviations file: ./config/channel_abbreviations.txt
- Path of the generic abbreviations file: ./config/generic_abbreviations.txt

Thank you and have a nice day :)