### PR TITLE
new: AppLocker Audit Mode - Application or Script Would Have Been Blo…

### DIFF
--- a/sigma/builtin/applocker/win_applocker_application_audited.yml
+++ b/sigma/builtin/applocker/win_applocker_application_audited.yml
@@ -1,0 +1,41 @@
+title: AppLocker Audit Mode - Application or Script Would Have Been Blocked
+id: b9d2a75d-a3c8-4b2e-8f1d-9e3c7d4a5b6e
+status: experimental
+description: |
+    Detects when AppLocker audit mode logs that an application, script or DLL
+    would have been blocked if AppLocker was enforced. Useful for identifying
+    potential policy gaps and bypass attempts.
+references:
+    - https://learn.microsoft.com/en-us/windows/security/application-security/application-control/windows-defender-application-control/applocker/what-is-applocker
+    - https://learn.microsoft.com/en-us/windows/security/application-security/application-control/windows-defender-application-control/applocker/using-event-viewer-with-applocker
+author: heyyanu
+date: 2026-02-25
+tags:
+    - attack.execution
+    - attack.defense_evasion
+    - attack.t1204.002
+    - attack.t1059.001
+    - attack.t1059.003
+    - attack.t1059.005
+    - attack.t1562.001
+logsource:
+    product: windows
+    service: applocker
+detection:
+    applocker:
+        Channel:
+            - Microsoft-Windows-AppLocker/MSI and Script
+            - Microsoft-Windows-AppLocker/EXE and DLL
+            - Microsoft-Windows-AppLocker/Packaged app-Deployment
+            - Microsoft-Windows-AppLocker/Packaged app-Execution
+    selection:
+        EventID:
+            - 8003 # EXE and DLL would have been blocked
+            - 8006 # MSI and Script would have been blocked
+            - 8023 # Packaged app execution would have been blocked
+            - 8024 # Packaged app deployment would have been blocked
+    condition: applocker and selection
+falsepositives:
+    - Expected during AppLocker policy testing and audit mode deployments
+level: low
+ruletype: Sigma


### PR DESCRIPTION
…cked - closes #767
**Summary**
Adds a new detection rule for AppLocker audit mode events where applications, 
scripts or DLLs would have been blocked if AppLocker was enforced.

Covers Event IDs:
- 8003: EXE and DLL would have been blocked
- 8006: MSI and Script would have been blocked  
- 8023: Packaged app execution would have been blocked
- 8024: Packaged app deployment would have been blocked

**Related Issue**
Closes #767

 **MITRE ATT&CK**
- T1204.002 - Malicious File
- T1059.001 - PowerShell
- T1562.001 - Defense Evasion